### PR TITLE
Rename Custom Context config #1

### DIFF
--- a/src/main/resources/assets/common/events.ts
+++ b/src/main/resources/assets/common/events.ts
@@ -10,8 +10,8 @@ export enum EnonicAiEvents {
     HIDE = 'EnonicAiContentOperatorHideEvent',
     APPLY = 'EnonicAiContentOperatorApplyEvent',
     OPEN_DIALOG = 'EnonicAiContentOperatorOpenDialogEvent',
+    CONFIG = 'EnonicAiContentOperatorConfigEvent',
     // Common
-    CONFIG = 'EnonicAiConfigEvent',
     DATA_SENT = 'EnonicAiDataSentEvent',
 }
 

--- a/src/main/resources/assets/requests/chat.ts
+++ b/src/main/resources/assets/requests/chat.ts
@@ -28,12 +28,14 @@ async function requestGenerate(
     fields?: SchemaField[],
 ): Promise<ModelResponseGenerateData | ErrorResponse> {
     const {mode} = $settings.get();
+    const {instructions} = $config.get();
     const schema: ResponseSchema | undefined = fields && {fields};
     const body = JSON.stringify({
         operation: 'generate',
         mode,
         messages,
         schema,
+        instructions,
     } satisfies ModelRequestGenerateData);
     const response = await fetch($config.get().serviceUrl, {method: 'POST', body});
 

--- a/src/main/resources/assets/stores/config.ts
+++ b/src/main/resources/assets/stores/config.ts
@@ -10,6 +10,7 @@ export type Config = {
         shortName: string;
     };
     locales: string[];
+    instructions: string;
 };
 
 export const $config = map<Config>({
@@ -19,12 +20,21 @@ export const $config = map<Config>({
         shortName: 'Y',
     },
     locales: ['en'],
+    instructions: '',
 });
 
 export const setServiceUrl = (serviceUrl: string): void => $config.setKey('serviceUrl', serviceUrl);
 export const setUser = (user: Config['user']): void => $config.setKey('user', user);
 export const setLocales = (locales: string[]): void => $config.setKey('locales', locales.slice());
+export const setInstructions = (instructions: string): void => $config.setKey('instructions', instructions);
 
 addGlobalConfigHandler((event: CustomEvent<ConfigData>) => {
-    setUser(event.detail.payload.user);
+    const {user, instructions} = event.detail.payload;
+
+    if (user) {
+        setUser(user);
+    }
+    if (instructions) {
+        setInstructions(instructions);
+    }
 });

--- a/src/main/resources/assets/stores/data.ts
+++ b/src/main/resources/assets/stores/data.ts
@@ -37,13 +37,11 @@ import {$scope, isScopeSet} from './scope';
 export type Data = {
     persisted: Optional<ContentData>;
     schema: Optional<Schema>;
-    customPrompt: Optional<string>;
 };
 
 export const $data = map<Data>({
     persisted: null,
     schema: null,
-    customPrompt: null,
 });
 
 export interface DataEntry {
@@ -66,16 +64,12 @@ export const getSchema = (): Optional<Readonly<Schema>> => $data.get().schema;
 
 export const setSchema = (schema: Schema): void => $data.setKey('schema', schema);
 
-export const setCustomPrompt = (customPrompt: string): void => $data.setKey('customPrompt', customPrompt);
-
-export const getCustomPrompt = (): Optional<string> => $data.get().customPrompt;
-
 function putEventDataToStore(eventData: EventData): void {
     if (!eventData['payload']) {
         return;
     }
 
-    const {schema, data, customPrompt} = eventData.payload;
+    const {schema, data} = eventData.payload;
 
     if (schema) {
         setSchema(schema);
@@ -83,10 +77,6 @@ function putEventDataToStore(eventData: EventData): void {
 
     if (data) {
         setPersistedData(data);
-    }
-
-    if (customPrompt) {
-        setCustomPrompt(customPrompt);
     }
 }
 
@@ -295,9 +285,7 @@ function generateTopicDataEntry(): DataEntry {
 }
 
 export function createPrompt(text: string): string {
-    return [text, createContext(), createFields(text), createContent(), createCustom()]
-        .filter(isNonNullable)
-        .join('\n\n');
+    return [text, createContext(), createFields(text), createContent()].filter(isNonNullable).join('\n\n');
 }
 
 function createContext(): string {
@@ -359,14 +347,6 @@ function createFields(text: string): Optional<string> {
 
 function createContent(): string {
     return ['#Content#', '```json', pathsEntriesToString(generatePathsEntries()), '```'].join('\n');
-}
-
-function createCustom(): Optional<string> {
-    const customPrompt = getCustomPrompt();
-    if (!customPrompt) {
-        return null;
-    }
-    return ['#Custom#', customPrompt].join('\n');
 }
 
 export function getPathType(path: InputWithPath | undefined): 'html' | 'text' {

--- a/src/main/resources/assets/stores/data/ConfigData.ts
+++ b/src/main/resources/assets/stores/data/ConfigData.ts
@@ -1,8 +1,9 @@
 export type ConfigData = {
     payload: {
-        user: {
+        user?: {
             fullName: string;
             shortName: string;
         };
+        instructions?: string;
     };
 };

--- a/src/main/resources/i18n/phrases.properties
+++ b/src/main/resources/i18n/phrases.properties
@@ -1,0 +1,2 @@
+# Input Types
+input.instructions.helpText=These custom instructions can tailor the conversation by setting guidelines for the AI’s behavior, tone, and content. These instructions can change the AI’s personality or adjust the level of formality in responses. For example, an instruction to "respond as a pirate captain" would alter the AI’s language and approach to answering questions.

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site xmlns="urn:enonic:xp:model:1.0">
     <form>
-        <input name="customPrompt" type="TextArea">
-            <label>Custom instructions</label>
+        <input name="instructions" type="TextArea">
+            <label>General Instructions</label>
+            <help-text i18n="input.instructions.helpText" />
             <occurrences minimum="0" maximum="1"/>
         </input>
     </form>


### PR DESCRIPTION
Renamed `customPrompt` to `instructions`.
Changed label in config to General instructions.
Added description for that input.
 
_Depends on https://github.com/enonic/app-contentstudio/pull/7885_