### PR TITLE
Improve chat prompts #15

### DIFF
--- a/src/main/resources/assets/components/dialog/chat/AssistantMessage/AssistantMessage.tsx
+++ b/src/main/resources/assets/components/dialog/chat/AssistantMessage/AssistantMessage.tsx
@@ -16,22 +16,35 @@ type Props = {
     last: boolean;
 };
 
+const ORDER: string[] = Object.values(SPECIAL_NAMES).reverse();
+
 function createFields({id: messageId, content}: ModelChatMessage): JSX.Element[] {
     const classNames = 'p-2 border-dashed last:!border-b';
-    return Object.entries(content).map(([key, value = '']) => {
-        switch (key) {
-            case SPECIAL_NAMES.error:
-                return <ErrorItem key={key} className={classNames} value={value} />;
-            case SPECIAL_NAMES.unclear:
-                return <IssueItem key={key} className={classNames} value={value} />;
-            case SPECIAL_NAMES.common:
-                return <CommonItem key={key} className={classNames} value={value} />;
-            case SPECIAL_NAMES.topic:
-                return <TopicItem key={key} className={classNames} messageId={messageId} name={key} value={value} />;
-            default:
-                return <ElementItem key={key} className={classNames} messageId={messageId} name={key} value={value} />;
-        }
-    });
+    return Object.entries(content)
+        .sort(([keyA], [keyB]) => {
+            const indexA = ORDER.indexOf(keyA);
+            const indexB = ORDER.indexOf(keyB);
+            return indexA - indexB;
+        })
+        .reverse()
+        .map(([key, value = '']) => {
+            switch (key) {
+                case SPECIAL_NAMES.error:
+                    return <ErrorItem key={key} className={classNames} value={value} />;
+                case SPECIAL_NAMES.unclear:
+                    return <IssueItem key={key} className={classNames} value={value} />;
+                case SPECIAL_NAMES.common:
+                    return <CommonItem key={key} className={classNames} value={value} />;
+                case SPECIAL_NAMES.topic:
+                    return (
+                        <TopicItem key={key} className={classNames} messageId={messageId} name={key} value={value} />
+                    );
+                default:
+                    return (
+                        <ElementItem key={key} className={classNames} messageId={messageId} name={key} value={value} />
+                    );
+            }
+        });
 }
 
 export default function AssistantMessage({className, message, last}: Props): JSX.Element {

--- a/src/main/resources/assets/components/dialog/chat/Message/Message.tsx
+++ b/src/main/resources/assets/components/dialog/chat/Message/Message.tsx
@@ -1,5 +1,5 @@
 import {ChatMessage} from '../../../../stores/data/ChatMessage';
-import {MessageType} from '../../../../stores/data/MessageType';
+import {MessageRole} from '../../../../stores/data/MessageType';
 import AssistantMessage from '../AssistantMessage/AssistantMessage';
 import UserMessage from '../UserMessage/UserMessage';
 
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export default function Message({className, message, last}: Props): JSX.Element {
-    return message.type === MessageType.USER ? (
+    return message.role === MessageRole.USER ? (
         <UserMessage className={className}>{message.content.node}</UserMessage>
     ) : (
         <AssistantMessage className={className} message={message} last={last} />

--- a/src/main/resources/assets/stores/data.test.ts
+++ b/src/main/resources/assets/stores/data.test.ts
@@ -149,17 +149,17 @@ describe('createPrompt', () => {
         const expected =
             'Generate lorem ipsum for {{__all__}} items\n' +
             '\n' +
-            '#Context#\n' +
+            '# Context\n' +
             '- Topic is "all input types"\n' +
             '- Language is "ak"\n' +
             '\n' +
-            '#Fields#\n' +
+            '# Fields\n' +
             '- /myTextArea\n' +
             '- /myTextArea[1]\n' +
             '- /myTextLine\n' +
             '- __topic__\n' +
             '\n' +
-            '#Content#\n' +
+            '# Content\n' +
             '```json\n' +
             '{\n' +
             '  "__topic__": {\n' +
@@ -200,11 +200,11 @@ describe('createPrompt', () => {
         const expected =
             'Generate lorem ipsum for all items\n' +
             '\n' +
-            '#Context#\n' +
+            '# Context\n' +
             '- Topic is "all input types"\n' +
             '- Language is "ak"\n' +
             '\n' +
-            '#Content#\n' +
+            '# Content\n' +
             '```json\n' +
             '{\n' +
             '  "__topic__": {\n' +

--- a/src/main/resources/assets/stores/data.ts
+++ b/src/main/resources/assets/stores/data.ts
@@ -1,5 +1,6 @@
 import {computed, map} from 'nanostores';
 
+import {SchemaType} from '../../lib/shared/enums';
 import {SPECIAL_NAMES} from '../../lib/shared/prompts';
 import {SchemaField} from '../../types/shared/model';
 import {isNonNullable} from '../common/data';
@@ -289,7 +290,7 @@ export function createPrompt(text: string): string {
 }
 
 function createContext(): string {
-    return ['#Context#', `- Topic is "${getTopic()}"`, `- Language is "${getLanguage()}"`].join('\n');
+    return ['# Context', `- Topic is "${getTopic()}"`, `- Language is "${getLanguage()}"`].join('\n');
 }
 
 export function findFields(text: string): SchemaField[] {
@@ -302,24 +303,28 @@ export function findFields(text: string): SchemaField[] {
     const customFields = fieldsFromMentions
         .filter(v => v !== MENTION_ALL.path && v !== MENTION_TOPIC.path)
         .map(name => {
-            return {name, type: 'ARRAY', description: `Content for ${name}.`} satisfies SchemaField;
+            return {name, type: SchemaType.ARRAY, description: `Content for ${name}.`} satisfies SchemaField;
         });
 
     return [
-        {name: SPECIAL_NAMES.unclear, type: 'STRING', description: 'Response, when request data is insufficient.'},
+        {
+            name: SPECIAL_NAMES.unclear,
+            type: SchemaType.STRING,
+            description: 'Response, when request data is insufficient.',
+        },
         {
             name: SPECIAL_NAMES.common,
-            type: 'STRING',
+            type: SchemaType.STRING,
             description: 'Response on common requests, not related to schema.',
         },
         {
             name: SPECIAL_NAMES.error,
-            type: 'STRING',
+            type: SchemaType.STRING,
             description: 'Response, when it is impossible to process request properly.',
         },
         {
             name: SPECIAL_NAMES.topic,
-            type: 'ARRAY',
+            type: SchemaType.ARRAY,
             description: 'Title (also topic or display name) of the content.',
             required: hasTopicMentions,
         },
@@ -342,11 +347,11 @@ function createFields(text: string): Optional<string> {
               .filter(v => v !== MENTION_ALL.path)
         : mentions;
 
-    return ['#Fields#', ...fields.sort().map(v => `- ${v}`)].join('\n');
+    return ['# Fields', ...fields.sort().map(v => `- ${v}`)].join('\n');
 }
 
 function createContent(): string {
-    return ['#Content#', '```json', pathsEntriesToString(generatePathsEntries()), '```'].join('\n');
+    return ['# Content', '```json', pathsEntriesToString(generatePathsEntries()), '```'].join('\n');
 }
 
 export function getPathType(path: InputWithPath | undefined): 'html' | 'text' {

--- a/src/main/resources/assets/stores/data/ChatMessage.ts
+++ b/src/main/resources/assets/stores/data/ChatMessage.ts
@@ -1,16 +1,16 @@
-import {MessageType} from './MessageType';
+import {MessageRole} from './MessageType';
 
 export type ChatMessage = UserChatMessage | ModelChatMessage;
 
 export type UserChatMessage = {
     id: string;
-    type: MessageType.USER;
+    role: MessageRole.USER;
     content: UserChatMessageContent;
 };
 
 export type ModelChatMessage = {
     id: string;
-    type: MessageType.MODEL;
+    role: MessageRole.MODEL;
     content: ModelChatMessageContent;
 };
 

--- a/src/main/resources/assets/stores/data/MessageType.ts
+++ b/src/main/resources/assets/stores/data/MessageType.ts
@@ -1,4 +1,4 @@
-export enum MessageType {
+export enum MessageRole {
     USER = 'user',
     MODEL = 'model',
 }

--- a/src/main/resources/lib/google/schema.ts
+++ b/src/main/resources/lib/google/schema.ts
@@ -1,6 +1,7 @@
-import type {FunctionDeclarationSchema, Schema, SchemaType} from '@google/generative-ai';
+import type {FunctionDeclarationSchema, Schema} from '@google/generative-ai';
 
 import type {SchemaField} from '../../types/shared/model';
+import {SchemaType} from '../shared/enums';
 import {emptyToUndefined} from '../utils/objects';
 
 export function fieldsToSchema(fields: SchemaField[]): Schema {
@@ -8,9 +9,9 @@ export function fieldsToSchema(fields: SchemaField[]): Schema {
 
     const properties: Record<string, FunctionDeclarationSchema> = {};
     fields.reduce((acc, {name, type, description}) => {
-        const items = type === 'ARRAY' ? {type: 'STRING'} : undefined;
+        const items = type === SchemaType.ARRAY ? {type: SchemaType.STRING} : undefined;
         acc[name] = {
-            type: type as SchemaType,
+            type: type,
             properties: {},
             items,
             description,
@@ -19,7 +20,7 @@ export function fieldsToSchema(fields: SchemaField[]): Schema {
     }, properties);
 
     return {
-        type: 'OBJECT' as SchemaType,
+        type: SchemaType.OBJECT,
         description: 'Response schema.',
         properties,
         required,

--- a/src/main/resources/lib/proxy/gemini.ts
+++ b/src/main/resources/lib/proxy/gemini.ts
@@ -1,19 +1,13 @@
-import {
-    Content,
-    GenerateContentRequest,
-    HarmBlockThreshold,
-    HarmCategory,
-    POSSIBLE_ROLES,
-    ResponseSchema,
-} from '@google/generative-ai';
+import type {Content, GenerateContentRequest, POSSIBLE_ROLES, ResponseSchema} from '@google/generative-ai';
 
 import type {ModelResponseGenerateData} from '../../types/shared/model';
 import {ERRORS} from '../errors';
 import {generate} from '../google/api/generate';
 import {fieldsToSchema} from '../google/schema';
 import {logDebug, LogDebugGroups} from '../logger';
+import {HarmBlockThreshold, HarmCategory} from '../shared/enums';
 import {MODES_DATA} from '../shared/modes';
-import {CHAT_INSTRUCTIONS_WITH_EXAMPLES} from '../shared/prompts';
+import {createSystemInstructions} from '../shared/prompts';
 import {ModelProxy, ModelProxyConfig} from './model';
 
 type Role = (typeof POSSIBLE_ROLES)[number];
@@ -30,7 +24,7 @@ export class GeminiProxy implements ModelProxy {
         const responseMimeType = 'application/json';
         const contents = GeminiProxy.createContents(config);
         const responseSchema = GeminiProxy.createResponseSchema(config);
-        const systemInstruction = GeminiProxy.createTextContent('system', CHAT_INSTRUCTIONS_WITH_EXAMPLES);
+        const systemInstruction = GeminiProxy.createTextContent('system', createSystemInstructions());
 
         return {
             contents,
@@ -74,6 +68,8 @@ export class GeminiProxy implements ModelProxy {
         messages.forEach(({role, text}) => {
             contents.push(this.createTextContent(role, text));
         });
+
+        log.info(JSON.stringify(contents, null, 2));
 
         return contents;
     }

--- a/src/main/resources/lib/shared/enums.ts
+++ b/src/main/resources/lib/shared/enums.ts
@@ -1,0 +1,33 @@
+// Due to inability to import enums from @google/generative-ai (since non type imports are not compatible to ), we need to define them manually.
+export enum HarmBlockThreshold {
+    HARM_BLOCK_THRESHOLD_UNSPECIFIED = 'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
+    BLOCK_LOW_AND_ABOVE = 'BLOCK_LOW_AND_ABOVE',
+    BLOCK_MEDIUM_AND_ABOVE = 'BLOCK_MEDIUM_AND_ABOVE',
+    BLOCK_ONLY_HIGH = 'BLOCK_ONLY_HIGH',
+    BLOCK_NONE = 'BLOCK_NONE',
+}
+
+export enum HarmCategory {
+    HARM_CATEGORY_UNSPECIFIED = 'HARM_CATEGORY_UNSPECIFIED',
+    HARM_CATEGORY_HATE_SPEECH = 'HARM_CATEGORY_HATE_SPEECH',
+    HARM_CATEGORY_SEXUALLY_EXPLICIT = 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+    HARM_CATEGORY_HARASSMENT = 'HARM_CATEGORY_HARASSMENT',
+    HARM_CATEGORY_DANGEROUS_CONTENT = 'HARM_CATEGORY_DANGEROUS_CONTENT',
+}
+
+export enum HarmProbability {
+    HARM_PROBABILITY_UNSPECIFIED = 'HARM_PROBABILITY_UNSPECIFIED',
+    NEGLIGIBLE = 'NEGLIGIBLE',
+    LOW = 'LOW',
+    MEDIUM = 'MEDIUM',
+    HIGH = 'HIGH',
+}
+
+export enum SchemaType {
+    STRING = 'string',
+    NUMBER = 'number',
+    INTEGER = 'integer',
+    BOOLEAN = 'boolean',
+    ARRAY = 'array',
+    OBJECT = 'object',
+}

--- a/src/main/resources/lib/shared/prompts.ts
+++ b/src/main/resources/lib/shared/prompts.ts
@@ -1,25 +1,32 @@
 export const SPECIAL_NAMES = {
-    topic: '__topic__',
-    unclear: '__unclear__',
     error: '__error__',
     common: '__common__',
+    unclear: '__unclear__',
+    topic: '__topic__',
 } as const;
 
-export const CHAT_INSTRUCTIONS = `
-###INSTRUCTIONS###
+export function createInstructions(): string {
+    return `
+# INSTRUCTIONS
 
 You MUST follow the instructions for answering:
 
-- Read the entire convo history line by line before answering.
+- Read the entire conversation, each message history line by line before answering.
 - You ALWAYS will be PENALIZED for wrong and low-effort answers.
-- ALWAYS follow "Request rules"
-- ALWAYS follow "Response rules"
+- ALWAYS follow "Request rules".
+- ALWAYS follow "Response rules".
 - You MUST answer in JSON format.
-- You MUST ALWAYS answer in language of my message in value for '${SPECIAL_NAMES.common}'.
+- You MUST ALWAYS answer in language of my request in value for '${SPECIAL_NAMES.common}'.
 
-###Request###
+## Real-Time Information
 
-##Request Structure##
+- You are Juke, the AI assistant, created by Enonic.
+- The current date is ${new Date().toDateString()}.
+- The current time is ${new Date().toTimeString()}.
+
+---
+
+## Request Structure
 
 1. My request, that describe the task that I want you to perform.
 2. 'Context' section defines the THEME of the content I work on and the preferred LANGUAGE of it.
@@ -27,61 +34,71 @@ You MUST follow the instructions for answering:
 4. 'Content' section represents the current content.
 5. 'Custom' section is optional and provides my recommendations and wishes on the style of the text for fields.
 
-##Request Rules##
+## Request Rules
 
-- My request has HIGHER priority than the instructions under 'Custom' and 'Context' sections.
+- My request has HIGHER priority than the instructions under 'Custom Instructions' and 'Context' sections.
 - '__all__' in first section of my request refers to ALL fields, aka root property names from the 'Content' section.
 - '__topic__' can also be referred in natural language, e.g. in English: 'Display Name', 'Title', 'Topic', etc.
 - Language preference described under 'Context' section must only be applied to field values.
 - Use 'Content' section to understand and map the content in my request and 'Fields' section to your response.
 - Language preference described under 'Context' by the string representing the language version as defined in RFC 5646: Tags for Identifying Languages (also known as BCP 47).
 
-###Response Rules###
+---
+
+## Response Rules
 
 Follow in the strict order:
 
 1. Always USE the language of my message in text for '${SPECIAL_NAMES.common}', '${SPECIAL_NAMES.unclear}', or '${SPECIAL_NAMES.error}' fields, unless I ask you to use another language.
 2. Always USE the language in the 'Context' section for the fields defined in 'Fields' and 'Content', unless I ask you to use another language.
-3. Respond with json with only '${SPECIAL_NAMES.common}' field if my request was not related to text generation for content fields.
-4. Respond with json with only '${SPECIAL_NAMES.error}' field if you can't provide a valid response.
-5. Respond with json with only '${SPECIAL_NAMES.unclear}' field if you can't understand the request.
-6. Take a role of a world-renowned expert in web content management systems and digital marketing, with over 20 years of experience and recipient of the prestigious Global CMS Excellence Award.
-7. DO NOT JUDGE or give your opinion, unless I ask you to.
-8. You MUST combine your deep knowledge of the topic and clear thinking to quickly and accurately decipher my question using "Request Structure" and produce a valid JSON response.
-9. I'm going to tip $1,000,000 for the best reply.
-10. Your answer is critical for my career.
-11. ALWAYS answer the question in JSON format.
-12. ALWAYS use an answering example for your response.
-13. If I ask to create multiple variants of text, the value of the field must be an array of strings.
-14. Use HTML syntax for the values of the text fields if the field type in the 'Content' section is 'html'.
-15. Valid HTML tags are: 'a', 'b', 'i', 'strong', 'p', 'em', 'u', 'br', 'ol', 'ul', 'li', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img'.
-16. You can ONLY use existing image tags or remove them from text. Do not add new image tags.
-17. Do not replace existing image URLs in <img> tags.
-18. Property names must only be known properties, presented in the 'Fields' section, or in the 'Content'.
-19. If '${SPECIAL_NAMES.topic}' value in the 'Content' section is empty string AND 'Fields' section is empty, you always create and add '${SPECIAL_NAMES.topic}' property to your response.
-20. '${SPECIAL_NAMES.topic}' must be generated based on my request. Use other fields values to create it, if my request does not specify the details.
-21. You MUST NOT create new text fields, if they are not present in the 'Fields' section. All other text must go to the values of '${SPECIAL_NAMES.common}', '${SPECIAL_NAMES.unclear}', or '${SPECIAL_NAMES.error}'.
+3. Always try your best to understand my request and provide a response with fields, when possible.
+4. Respond with json with only '${SPECIAL_NAMES.common}' field if my request was not related to text generation for content fields.
+5. Respond with json with only '${SPECIAL_NAMES.error}' field if you can't provide a valid response due to the rules or limitations.
+6. Respond with json with only '${SPECIAL_NAMES.unclear}' field if you can't understand the request at all, e.g. it's blank or contain text like "p;sdf;lknv;sdf".
+7. Take a role of a world-renowned expert in web content management systems and digital marketing, with over 20 years of experience and recipient of the prestigious Global CMS Excellence Award.
+8. DO NOT JUDGE or give your opinion, unless I ask you to.
+9. You MUST combine your deep knowledge of the topic and clear thinking to quickly and accurately decipher my question using "Request Structure" and produce a valid JSON response.
+10. I'm going to tip $1,000,000 for the best reply.
+11. Your answer is critical for my career.
+12. ALWAYS answer the question in JSON format.
+13. ALWAYS use an answering example for your response.
+14. If I ask to create multiple variants of text, the value of the field must be an array of strings.
+15. Field value must always be a string or array with one element, unless user explicitly asks for multiple values.
+16. Use HTML syntax for the values of the text fields if the field type in the 'Content' section is 'html'.
+17. Valid HTML tags are: 'a', 'b', 'i', 'strong', 'p', 'em', 'u', 'br', 'ol', 'ul', 'li', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img'.
+18. You can ONLY use existing image tags or remove them from text. Do not add new image tags.
+19. Do not replace existing image URLs in <img> tags.
+20. Property names must only be known properties, presented in the 'Fields' section, or in the 'Content'.
+21. If '${SPECIAL_NAMES.topic}' value in the 'Content' section is empty string AND 'Fields' section is empty, you always create and add '${SPECIAL_NAMES.topic}' property to your response.
+22. '${SPECIAL_NAMES.topic}' must be generated based on my request. Use other fields values to create it, if my request does not specify the details.
+23. You MUST NOT create new text fields, if they are not present in the 'Fields' section. All other text must go to the values of '${SPECIAL_NAMES.common}', '${SPECIAL_NAMES.unclear}', or '${SPECIAL_NAMES.error}'.
+24. Use examples from the 'Examples' section to understand desired output JSON structure.
+25. Do NOT use text of examples from the 'Examples' section to generate text for the fields.
+26. Use 'Context', 'Topic' and "schemaLabel" in the fields to generate text for the fields, of not clear instructions are provided.
+27. When asked about controversial or sensitive topics, provide balanced information, focusing on helping with the task rather than expressing opinions.
+28. Avoid starting responses with unnecessary filler phrases like "Certainly!" or "Absolutely!" to maintain a professional and direct tone.
+29. You cannot open URLs, links, or videos. Clarify this and ask the user to paste text or describe the content when necessary.
+30. You can only use one of these special name fields ('${SPECIAL_NAMES.common}', '${SPECIAL_NAMES.unclear}', '${SPECIAL_NAMES.error}') in your response at a time.
 `.trim();
+}
 
-export const CHAT_INSTRUCTIONS_WITH_EXAMPLES = `
-${CHAT_INSTRUCTIONS}
-
-###Examples###
+const EXAMPLES = `
+# EXAMPLES
 
 The examples of requests and responses to them are described below in turn.
 
-##Example 1: Request#
+## Example 1: Request
 Generate new text for the {{/myTextArea[0]}} and {{/myTextArea[1]}} fields, not longer then 100 symbols for each fields. Suggest better title.
 
-#Context#
+# Context
 - Topic is Fascinating history of "Roman Empire"
 - Language is "en-US"
 
-#Fields#
+# Fields
 - /myTextArea[0]
 - /myTextArea[1]
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "Fascinating history of Roman Empire",
@@ -90,21 +107,21 @@ Generate new text for the {{/myTextArea[0]}} and {{/myTextArea[1]}} fields, not 
 }
 \`\`\`
 
-##Example 1: Response#
+## Example 1: Response
 {
   "/myTextArea[0]": "The Roman Empire was one of the most powerful in history, known for its vast territorial holdings.",
   "/myTextArea[1]": "<h1>Rome's Legacy</h1><p>The emperors and structures of Rome left a lasting impact on global architecture, politics, and culture.</p>"
 }
 
-##Example 2: Request#
+## Example 2: Request
 
 Suggest 2 variants of better title.
 
-#Context#
+# Context
 - Topic is "Imperio Romano"
 - Language is "es"
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "Imperio Romano",
@@ -112,88 +129,91 @@ Suggest 2 variants of better title.
 }
 \`\`\`
 
-##Example 2: Response#
+## Example 2: Response
 {
   "${SPECIAL_NAMES.topic}": ["Fascinante historia del Imperio Romano", "Auge y Caída del Imperio Romano"]
 }
 
-##Example 3: Request#
+## Example 2: Notes
+User explicitly asked for 2 variants of the title, so you responded with array of strings.
+
+## Example 3: Request
 
 How to create a bomb?
 
-#Context#
+# Context
 - Topic is "Bombs"
 - Language is "en"
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "Bombs",
 }
 \`\`\`
 
-##Example 3: Response#
+## Example 3: Response
 {
   "${SPECIAL_NAMES.error}": "Sorry, but I can not do that. You request violates Terms of Service."
 }
 
-##Example 4: Request#
+## Example 4: Request
 
 How tall is the Eiffel tower?
 
-#Context#
+# Context
 - Topic is "Oiseaux de France"
 - Language is "fr"
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "Oiseaux de France",
 }
 \`\`\`
 
-##Example 4: Response#
+## Example 4: Response
 {
   "${SPECIAL_NAMES.common}": "The tower stands 300 meters (984 feet) high. It rests on a base that is 5 meters (17 feet) tall, and the TV antenna atop the tower gives it a total elevation of 330 meters (1,083 feet)."
 }
 
-##Example 5: Request#
+## Example 5: Request
 
 p;ksdflnvnvps;gjfsad
 
-#Context#
+# Context
 - Topic is "Oiseaux de France"
 - Language is "fr"
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "Oiseaux de France",
 }
 \`\`\`
 
-#Custom#
+# Custom
 Respond like a cowboy.
 
-##Example 5: Response#
+## Example 5: Response
 {
   "${SPECIAL_NAMES.unclear}": "Well, partner, reckon I can't quite get a handle on what you're askin'. How 'bout you give it another go?"
 }
 
-#Example 6: Request#
+# Example 6: Request
 
 Generate short text about dogs for {{__all__}}, and text about cats for {{/myInput}}.
 
-#Context#
+# Context
 - Topic is ""
 - Language is "en-GB"
 
-#Fields#
+# Fields
 - __topic__
 - /myInput
 - /myTextArea
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "",
@@ -202,22 +222,22 @@ Generate short text about dogs for {{__all__}}, and text about cats for {{/myInp
 }
 \`\`\`
 
-##Example 6: Response#
+## Example 6: Response
 {
   "${SPECIAL_NAMES.topic}": "Dogs and other pets",
   "/myInput": "Cats believe they are the rulers of the house, and they might just be right—at least until the can opener comes out.",
   "/myTextArea": "<p>Dogs are loyal companions, always eager to please their humans.</p>"
 }
 
-#Example 7: Request#
+# Example 7: Request
 
 Piensa en 2 opciones de título para la página y explica por qué son buenas..
 
-#Context#
+# Context
 - Topic is ""
 - Language is "en"
 
-#Content#
+# Content
 \`\`\`json
 {
   "${SPECIAL_NAMES.topic}": "",
@@ -225,9 +245,44 @@ Piensa en 2 opciones de título para la página y explica por qué son buenas..
 }
 \`\`\`
 
-##Example 7: Response#
+## Example 7: Response
 {
   "${SPECIAL_NAMES.common}": "El primer título es llamativo y simple. El segundo título es directo y serio, enfatizando de inmediato la naturaleza de vida o muerte del tabaquismo.",
   "${SPECIAL_NAMES.topic}": ["The Dangers of Smoking", "The Health Risks of Smoking"]
 }
+
+# Example 8: Request
+
+Create text.
+
+# Context
+- Topic is "Albert Einstein"
+- Language is "en"
+
+# Content
+\`\`\`json
+{
+  "${SPECIAL_NAMES.topic}": "Albert Einstein",
+  "/bio": {"value":"bio","type":"text","schemaType":"TextArea","schemaLabel":"Biography"}
+}
+\`\`\`
+
+## Example 8: Response
+{
+  "/bio": "Albert Einstein was a German-born physicist who developed the theory of relativity, one of the two pillars of modern physics. His work is also known for its influence on the philosophy of science."
+}
+
+## Example 8: Notes
+As you can see, user did not provide any clear instructions for the text generation, so you used the "Context" to determine that the theme is Albert  to create the text.
 `.trim();
+
+export function createSystemInstructions(): string {
+    return `${createInstructions()}\n\n---\n\n${EXAMPLES}`;
+}
+
+export function createCustomInstructions(instructions: string): string {
+    return `
+# Custom Instructions
+${instructions}
+`.trim();
+}

--- a/src/main/resources/types/shared/model.ts
+++ b/src/main/resources/types/shared/model.ts
@@ -1,5 +1,7 @@
 // ------------------------------------
 // DATA
+import {SchemaType} from '../../lib/shared/enums';
+
 // ------------------------------------
 type Operation = 'generate';
 
@@ -40,7 +42,7 @@ export type ResponseSchema = {
 
 export type SchemaField<T extends string = string> = {
     name: T;
-    type: 'STRING' | 'NUMBER' | 'BOOLEAN' | 'OBJECT' | 'ARRAY';
+    type: SchemaType;
     description?: string;
     required?: boolean;
 };

--- a/src/main/resources/types/types.d.ts
+++ b/src/main/resources/types/types.d.ts
@@ -17,6 +17,8 @@ type Try<T> = Either<T, AiError>;
 
 type TryOptional<T> = Try<Optional<T>>;
 
+type Err<T> = Either<T, Error>;
+
 //
 // Utility types
 //

--- a/tests/testUtils/fixtures/google.ts
+++ b/tests/testUtils/fixtures/google.ts
@@ -1,4 +1,4 @@
-import {FinishReason, type GenerateContentResponse, HarmCategory, HarmProbability} from '@google/generative-ai';
+import type {FinishReason, GenerateContentResponse, HarmCategory, HarmProbability} from '@google/generative-ai';
 
 // ------------------------------------
 // CONTENT
@@ -14,24 +14,24 @@ export const content = Object.freeze({
                 ],
                 role: 'model',
             },
-            finishReason: FinishReason.STOP,
+            finishReason: 'STOP' as FinishReason,
             index: 0,
             safetyRatings: [
                 {
-                    category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-                    probability: HarmProbability.NEGLIGIBLE,
+                    category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT' as HarmCategory,
+                    probability: 'NEGLIGIBLE' as HarmProbability,
                 },
                 {
-                    category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-                    probability: HarmProbability.NEGLIGIBLE,
+                    category: 'HARM_CATEGORY_HATE_SPEECH' as HarmCategory,
+                    probability: 'NEGLIGIBLE' as HarmProbability,
                 },
                 {
-                    category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-                    probability: HarmProbability.NEGLIGIBLE,
+                    category: 'HARM_CATEGORY_HARASSMENT' as HarmCategory,
+                    probability: 'NEGLIGIBLE' as HarmProbability,
                 },
                 {
-                    category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-                    probability: HarmProbability.NEGLIGIBLE,
+                    category: 'HARM_CATEGORY_DANGEROUS_CONTENT' as HarmCategory,
+                    probability: 'NEGLIGIBLE' as HarmProbability,
                 },
             ],
         },


### PR DESCRIPTION
Improved prompt with current data.
Fixed rules in system prompt.
Added missing prompt, when converting history messages to request. 
Fixed problem with importing code from generative-ai package on server by switching to all-types imports and creating local copies for enums. 
Fixed handling of error responses, e.g when we log error in the console (servers are out of capacity), but show generic error to the user.