### PR TITLE
Add support for multiple Gemini models #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Content Operator, the Enonic's Juke AI plugin, is crafted to optimize and elevat
 ```properties
 # Gemini Model URL on Google APIs
 # `*:generateContent` last part must be dropped, as streaming support handled by the application
-google.api.gemini.url=https://us-central1-aiplatform.googleapis.com/v1/projects/playground-186616/locations/us-central1/publishers/google/models/gemini-1.5-pro-001
+#   Flash model (will be used for fast responses)
+google.api.gemini.flash.url=https://us-central1-aiplatform.googleapis.com/v1/projects/playground-186616/locations/us-central1/publishers/google/models/gemini-1.5-flash-001
+#   Pro model (will be used for accurate responses)
+google.api.gemini.pro.url=https://us-central1-aiplatform.googleapis.com/v1/projects/playground-186616/locations/us-central1/publishers/google/models/gemini-1.5-pro-001
 
 # Path to Google's Service Account Key (a JSON file)
 google.api.sak.path=/Users/enonic/config/playground-186416-e13cb1741f87.json

--- a/src/main/resources/assets/requests/chat.ts
+++ b/src/main/resources/assets/requests/chat.ts
@@ -32,6 +32,7 @@ async function requestGenerate(
     const schema: ResponseSchema | undefined = fields && {fields};
     const body = JSON.stringify({
         operation: 'generate',
+        model: 'pro',
         mode,
         messages,
         schema,

--- a/src/main/resources/assets/stores/chat.ts
+++ b/src/main/resources/assets/stores/chat.ts
@@ -104,7 +104,7 @@ async function sendMessages(messages: Message[], fields: SchemaField[]): Promise
 
 function handleResponse([response, error]: Err<ModelResponseGenerateData | ErrorResponse>): void {
     if (error) {
-        addCompleteModelMessage(createErrorContent(String(error)));
+        addCompleteModelMessage(createErrorContent(error.message));
         return;
     }
 

--- a/src/main/resources/assets/stores/requests.ts
+++ b/src/main/resources/assets/stores/requests.ts
@@ -40,9 +40,10 @@ async function attachRequest<T extends ModelPostResponse, K extends keyof Reques
         $requests.setKey(key, {state: RequestState.DONE});
         return [data, null];
     } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
         $requests.setKey(key, {state: RequestState.ERROR});
-        console.error(`[Enonic AI] Failed to complete request "${key}". Reason: ${String(e)}`);
-        return [null, Error(String(e))];
+        console.error(`[Enonic AI] Failed to complete request "${key}". Reason: ${msg}`);
+        return [null, Error(msg)];
     }
 }
 

--- a/src/main/resources/lib/config.ts
+++ b/src/main/resources/lib/config.ts
@@ -1,4 +1,5 @@
-export const GOOGLE_GEMINI_URL: string | null = app.config['google.api.gemini.url'] ?? null;
+export const GOOGLE_GEMINI_FLASH_URL: string | null = app.config['google.api.gemini.flash.url'] ?? null;
+export const GOOGLE_GEMINI_PRO_URL: string | null = app.config['google.api.gemini.pro.url'] ?? null;
 export const GOOGLE_SAK_PATH: string | null = app.config['google.api.sak.path'] ?? null;
 export const DEBUG_GROUPS: string[] = parseList(app.config['log.debug.groups']);
 

--- a/src/main/resources/lib/errors.ts
+++ b/src/main/resources/lib/errors.ts
@@ -4,8 +4,8 @@ export class CustomAiError implements AiError {
         public message: string,
     ) {}
 
-    withMsg(message: string): CustomAiError {
-        return new CustomAiError(this.code, message);
+    withMsg(message: string, replace?: boolean): CustomAiError {
+        return new CustomAiError(this.code, replace ? message : `${this.message} ${message}`);
     }
 
     toString(): string {
@@ -19,10 +19,11 @@ export const ERRORS = {
     // REST Errors 0000
     REST_REQUEST_FAILED: err(0, 'REST request failed.'),
     RESPONSE_BODY_MISSING: err(1, 'REST response body is missing.'),
-    REST_MODE_REQUIRED: err(10, 'Mode is required.'),
-    REST_MESSAGES_REQUIRED: err(11, 'Messages are required.'),
-    REST_FIELDS_REQUIRED: err(12, 'Fields are required.'),
-    REST_REQUEST_PARAMS_MISSING: err(13, 'Request params are missing.'),
+    REST_MODEL_REQUIRED: err(10, 'Model is required.'),
+    REST_MODE_REQUIRED: err(11, 'Mode is required.'),
+    REST_MESSAGES_REQUIRED: err(12, 'Messages are required.'),
+    REST_FIELDS_REQUIRED: err(13, 'Fields are required.'),
+    REST_REQUEST_PARAMS_MISSING: err(14, 'Request params are missing.'),
     REST_REQUEST_BODY_MISSING: err(20, 'Request body is missing.'),
     REST_OPERATION_NOT_SUPPORTED: err(21, 'Operation not supported.'),
     REST_NOT_AUTHENTICATED: err(401, 'Not authenticated.'),
@@ -34,8 +35,8 @@ export const ERRORS = {
 
     // Function Errors 3000
     FUNC_INSUFFICIENT_DATA: err(3000, 'Insufficient data.'),
-    FUNC_UNKNOWN_MODE: err(3001, 'Unknown AI mode.'),
-
+    FUNC_UNKNOWN_MODEL: err(3001, 'Unknown AI model.'),
+    FUNC_UNKNOWN_MODE: err(3002, 'Unknown AI mode.'),
     // Model Errors 4000
 
     // Google Errors 5000

--- a/src/main/resources/lib/google/api/generate.test.ts
+++ b/src/main/resources/lib/google/api/generate.test.ts
@@ -16,6 +16,9 @@ type MockedClient = Client & {
     sendPostRequest: MockedResponse;
 };
 
+const url =
+    'https://us-central1-aiplatform.googleapis.com/v1/projects/playground-123456/locations/us-central1/publishers/google/models/gemini-1.5-flash-001';
+
 jest.mock('../client', () => {
     const originalModule = jest.requireActual<Client>('../client');
     return {
@@ -43,18 +46,18 @@ describe('generate', () => {
     it('should generate content', () => {
         mocks.sendPostRequest.mockImplementationOnce(() => [createResponse(content), null]);
 
-        const [result, err] = generate(params);
+        const [result, err] = generate(url, params);
 
         expect(result).toEqual(content);
         expect(err).toBeNull();
 
-        expect(mocks.sendPostRequest).toHaveBeenCalledWith(params);
+        expect(mocks.sendPostRequest).toHaveBeenCalledWith(url, params);
     });
 
     it('should return an error if content cannot be generated', () => {
         mocks.sendPostRequest.mockImplementationOnce(() => [null, ERRORS.REST_REQUEST_FAILED]);
 
-        const [result, err] = generate(params);
+        const [result, err] = generate(url, params);
 
         expect(result).toBeNull();
         expect(err).toEqual(ERRORS.REST_REQUEST_FAILED);

--- a/src/main/resources/lib/google/api/generate.ts
+++ b/src/main/resources/lib/google/api/generate.ts
@@ -9,10 +9,10 @@ export type GenerationMeta = {
     schema?: ResponseSchema;
 };
 
-export function generate(params: GenerateContentRequest): Try<GenerateContentResponse> {
+export function generate(url: string, params: GenerateContentRequest): Try<GenerateContentResponse> {
     logDebug(LogDebugGroups.GOOGLE, `generate.generate(${JSON.stringify(params)})`);
 
-    const [response, err] = sendPostRequest(params);
+    const [response, err] = sendPostRequest(url, params);
     if (err) {
         return [null, err];
     }

--- a/src/main/resources/lib/google/client.ts
+++ b/src/main/resources/lib/google/client.ts
@@ -5,7 +5,7 @@ import {logDebug, LogDebugGroups, logError} from '../logger';
 import {request, RequestParams} from '../requests';
 import {getOptions} from './options';
 
-type GoogleRequestOptions = Omit<RequestParams, 'url'> & {
+type GoogleRequestOptions = RequestParams & {
     method: Enonic.HttpMethod;
 };
 
@@ -26,9 +26,9 @@ function sendRequest(params: GoogleRequestOptions): Try<HttpClientResponse> {
     if (err) {
         return [null, err];
     }
-    const {accessToken, url} = options;
+    const {accessToken} = options;
 
-    logDebug(LogDebugGroups.GOOGLE, `client.sendRequest(${params?.method}}) url: ${url}`);
+    logDebug(LogDebugGroups.GOOGLE, `client.sendRequest(${params?.method}}) url: ${params.url}`);
 
     const headers: GoogleHeaders = {
         ...(params.headers ?? {}),
@@ -38,12 +38,11 @@ function sendRequest(params: GoogleRequestOptions): Try<HttpClientResponse> {
     return request({
         ...params,
         headers,
-        url,
     });
 }
 
-export function sendPostRequest(body?: unknown): Try<HttpClientResponse> {
-    return sendRequest({method: 'POST', body});
+export function sendPostRequest(url: string, body?: unknown): Try<HttpClientResponse> {
+    return sendRequest({url, method: 'POST', body});
 }
 
 export function parseResponse<Data, Body = unknown>(

--- a/src/main/resources/lib/proxy/gemini.ts
+++ b/src/main/resources/lib/proxy/gemini.ts
@@ -13,9 +13,11 @@ import {ModelProxy, ModelProxyConfig} from './model';
 type Role = (typeof POSSIBLE_ROLES)[number];
 
 export class GeminiProxy implements ModelProxy {
+    private readonly url: string;
     private readonly params: GenerateContentRequest;
 
     constructor(config: ModelProxyConfig) {
+        this.url = config.url;
         this.params = GeminiProxy.createRequestParams(config);
     }
 
@@ -69,8 +71,6 @@ export class GeminiProxy implements ModelProxy {
             contents.push(this.createTextContent(role, text));
         });
 
-        log.info(JSON.stringify(contents, null, 2));
-
         return contents;
     }
 
@@ -81,8 +81,8 @@ export class GeminiProxy implements ModelProxy {
         };
     }
 
-    private static createResponseSchema({schema, model}: ModelProxyConfig): ResponseSchema | undefined {
-        const isSchemaSupported = model.startsWith('gemini-1.5-pro');
+    private static createResponseSchema({schema, modelName}: ModelProxyConfig): ResponseSchema | undefined {
+        const isSchemaSupported = modelName.startsWith('gemini-1.5-pro');
         const hasSchema = schema != null && schema.fields.length > 0;
 
         return isSchemaSupported && hasSchema ? fieldsToSchema(schema.fields) : undefined;
@@ -95,7 +95,7 @@ export class GeminiProxy implements ModelProxy {
     generate(): Try<ModelResponseGenerateData> {
         logDebug(LogDebugGroups.FUNC, 'gemini.GeminiProxy.generate()');
 
-        const [response, err] = generate(this.params);
+        const [response, err] = generate(this.url, this.params);
         if (err) {
             return [null, err];
         }

--- a/src/main/resources/lib/proxy/model.ts
+++ b/src/main/resources/lib/proxy/model.ts
@@ -1,4 +1,5 @@
 import type {Message, ModelResponseGenerateData, ResponseSchema} from '../../types/shared/model';
+import {Model, MODELS} from '../shared/models';
 import {Mode, MODES} from '../shared/modes';
 import {find} from '../utils/objects';
 
@@ -7,15 +8,16 @@ export type ModelProxy = {
 };
 
 export type ModelProxyConfig = {
-    model: string;
+    modelName: string;
     mode: Mode;
+    url: string;
     instructions?: string;
     messages: Message[];
     schema?: ResponseSchema;
 };
 
-export function isMode(mode: unknown): mode is Mode {
-    return mode != null && typeof mode === 'string' && MODES.indexOf(mode as Mode) >= 0;
+export function validateModel(model: unknown): Optional<Model> {
+    return find(MODELS, m => m === model);
 }
 
 export function validateMode(mode: unknown): Optional<Mode> {

--- a/src/main/resources/lib/proxy/proxy.ts
+++ b/src/main/resources/lib/proxy/proxy.ts
@@ -1,19 +1,26 @@
 import {ERRORS} from '../errors';
 import {getOptions} from '../google/options';
 import {logDebug, LogDebugGroups} from '../logger';
-import {DEFAULT_MODE, Mode} from '../shared/modes';
+import {DEFAULT_MODEL, isModel, Model} from '../shared/models';
+import {DEFAULT_MODE, isMode, Mode} from '../shared/modes';
 import {GeminiProxy} from './gemini';
-import {isMode, ModelProxy, ModelProxyConfig} from './model';
+import {ModelProxy, ModelProxyConfig} from './model';
 
-type ConnectionConfig = Omit<ModelProxyConfig, 'model' | 'mode'> & {
+type ConnectionConfig = Omit<ModelProxyConfig, 'modelName' | 'mode' | 'url'> & {
+    model: Optional<Model>;
     mode: Optional<Mode>;
 };
 
-export function connect({mode, instructions, messages, schema}: ConnectionConfig): Try<ModelProxy> {
+export function connect({model, mode, instructions, messages, schema}: ConnectionConfig): Try<ModelProxy> {
     logDebug(
         LogDebugGroups.FUNC,
         `proxy.connect(${mode}, [instructions: ${instructions?.length ?? 0}], [messages: ${messages.length}], ${schema ? '[schema]' : undefined})`,
     );
+
+    const preferredModel = model || DEFAULT_MODEL;
+    if (!isModel(preferredModel)) {
+        return [null, ERRORS.FUNC_UNKNOWN_MODEL];
+    }
 
     const preferredMode = mode || DEFAULT_MODE;
     if (!isMode(preferredMode)) {
@@ -24,8 +31,8 @@ export function connect({mode, instructions, messages, schema}: ConnectionConfig
     if (err) {
         return [null, err];
     }
-    const {model} = options;
+    const {url, name} = options[preferredModel];
 
-    const config = {model, mode: preferredMode, instructions, messages, schema};
+    const config = {modelName: name, mode: preferredMode, url, instructions, messages, schema};
     return [new GeminiProxy(config), null];
 }

--- a/src/main/resources/lib/shared/models.ts
+++ b/src/main/resources/lib/shared/models.ts
@@ -1,0 +1,8 @@
+export const MODELS = ['flash', 'pro'] as const;
+export type Model = (typeof MODELS)[number];
+
+export const DEFAULT_MODEL: Model = 'pro';
+
+export function isModel(model: unknown): model is Model {
+    return model != null && typeof model === 'string' && MODELS.indexOf(model as Model) >= 0;
+}

--- a/src/main/resources/lib/shared/modes.ts
+++ b/src/main/resources/lib/shared/modes.ts
@@ -43,3 +43,7 @@ export type ModelMeta = {
     model: string;
     mode: Mode;
 };
+
+export function isMode(mode: unknown): mode is Mode {
+    return mode != null && typeof mode === 'string' && MODES.indexOf(mode as Mode) >= 0;
+}

--- a/src/main/resources/services/rest/rest.ts
+++ b/src/main/resources/services/rest/rest.ts
@@ -2,7 +2,7 @@ import * as authLib from '/lib/xp/auth';
 
 import {ERRORS} from '../../lib/errors';
 import {logDebug, LogDebugGroups, logError} from '../../lib/logger';
-import {ModelProxy, validateMode} from '../../lib/proxy/model';
+import {ModelProxy, validateMode, validateModel} from '../../lib/proxy/model';
 import {connect} from '../../lib/proxy/proxy';
 import {respondData, respondError} from '../../lib/requests';
 import type {ModelPostResponse, ModelRequestData} from '../../types/shared/model';
@@ -34,9 +34,10 @@ export function post(request: Enonic.Request): Enonic.Response<ModelPostResponse
 }
 
 function connectModel(data: ModelRequestData): Try<ModelProxy> {
+    const model = validateModel(data.model);
     const mode = validateMode(data.mode);
     const {instructions, messages, schema} = data;
-    return connect({mode, instructions, messages, schema});
+    return connect({model, mode, instructions, messages, schema});
 }
 
 function parsePostRequest(request: Enonic.Request): Try<ModelRequestData> {
@@ -48,6 +49,9 @@ function parsePostRequest(request: Enonic.Request): Try<ModelRequestData> {
 
     switch (body.operation) {
         case 'generate':
+            if (body.model == null) {
+                return [null, ERRORS.REST_MODEL_REQUIRED];
+            }
             if (body.mode == null) {
                 return [null, ERRORS.REST_MODE_REQUIRED];
             }

--- a/src/main/resources/types/shared/model.ts
+++ b/src/main/resources/types/shared/model.ts
@@ -1,6 +1,7 @@
 // ------------------------------------
 // DATA
 import {SchemaType} from '../../lib/shared/enums';
+import {Model} from '../../lib/shared/models';
 
 // ------------------------------------
 type Operation = 'generate';
@@ -30,6 +31,7 @@ export type FinishReason =
 // ------------------------------------
 export type ModelRequestData = ModelRequestGenerateData;
 export type ModelRequestGenerateData = OperationData<'generate'> & {
+    model: Model;
     mode: string;
     instructions?: string;
     messages: Message[];


### PR DESCRIPTION
Added support for multiple models: flash (fast one), and pro (heavy, but more precise). 
Fixed `withMsg` always replacing original message, when it shouldn't.