### PR TITLE
Update timeout in HTTP Library requests #138

### DIFF
--- a/src/main/resources/lib/requests.ts
+++ b/src/main/resources/lib/requests.ts
@@ -29,7 +29,7 @@ export function request({
                     ...headers,
                 },
                 connectionTimeout: 60000,
-                readTimeout: 10000,
+                readTimeout: 60000,
                 body: body != null ? JSON.stringify(body) : undefined,
                 queryParams,
             }) ?? null,


### PR DESCRIPTION
Made first byte read timeout to 60s as reasonable time to wait for long generations.