### PR TITLE
Application styles are not scoped #196

### DIFF
--- a/src/main/resources/assets/index.tsx
+++ b/src/main/resources/assets/index.tsx
@@ -16,15 +16,16 @@ export function render(buttonContainer: HTMLElement, dialogContainer: HTMLElemen
         console.warn('[Enonic AI] Content Operator was rendered before configured.');
     }
 
+    buttonContainer.classList.add('ai-content-operator');
     const buttonRoot = createRoot(buttonContainer);
-    const dialogRoot = createRoot(dialogContainer);
-
     buttonRoot.render(
         <React.StrictMode>
             <LaunchButton />
         </React.StrictMode>,
     );
 
+    dialogContainer.classList.add('ai-content-operator');
+    const dialogRoot = createRoot(dialogContainer);
     dialogRoot.render(
         <React.StrictMode>
             <AssistantDialog />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -99,10 +99,11 @@ export default {
         },
     },
     safelist: ['animate-slide-fade-in'],
+    important: '.ai-content-operator', // isolate tailwind utility styles
     plugins: [
         require('@tailwindcss/typography'),
         scopedPreflightStyles({
-            isolationStrategy: isolateInsideOfContainer('.ai-content-operator'),
+            isolationStrategy: isolateInsideOfContainer('.ai-content-operator'), // isolate preflight styles
         }),
     ],
 };


### PR DESCRIPTION
`isolationStrategy` isolates only preflight styles, added `important` to isolate utility styles ('text-sm', 'p-2' etc), but had to use parent selector since the styles are now getting applied _within_ the selector and not to the whole document.

NB: Didn't manage to handle typography plugin, so it is being included in the resulting css as before and remains an issue