### PR TITLE
Keep WebSocket open only when dialog is visible #202

### DIFF
--- a/src/main/resources/assets/components/dialog/AssistantDialog/AssistantDialog.tsx
+++ b/src/main/resources/assets/components/dialog/AssistantDialog/AssistantDialog.tsx
@@ -21,7 +21,11 @@ export default function AssistantDialog({className = ''}: Props): React.ReactNod
     const [dragging, setDragging] = useState(false);
     const ref = useRef<HTMLDivElement>(null);
 
-    useEffect(() => mountWebSocket(), []);
+    useEffect(() => {
+        if (!hidden) {
+            return mountWebSocket();
+        }
+    }, [hidden]);
 
     useEffect(() => {
         const liveFrame = document.querySelector<HTMLElement>('.live-edit-frame');


### PR DESCRIPTION
Made WebSocket connect only when the dialog is rendered and visible, and disconnect in any other case.

> Note that WS will not instantly disconnect if the dialog has been closed. It will wait for the generation to complete. If the dialog was opened again and generation was still in progress, WS will not be disconnected.