### PR TITLE
Fields in chat do not reflect fields in the form #356

### DIFF
--- a/src/main/resources/assets/stores/data.ts
+++ b/src/main/resources/assets/stores/data.ts
@@ -86,9 +86,12 @@ export const $topic = computed($data, data => data.persisted?.topic ?? '');
 export const $allFormItemsWithPaths = computed($data, ({schema, persisted}) => {
     const schemaPaths = schema ? getFormItemsWithPaths(schema.form.formItems) : [];
     const result = persisted ? getDataPathsToEditableItems(schemaPaths, persisted) : [];
-    result.push(createDisplayNameInput());
 
-    return result;
+    return [createDisplayNameInput(), ...result];
+});
+
+export const $orderedPaths = computed($allFormItemsWithPaths, items => {
+    return items.map(item => pathToString(item));
 });
 
 //


### PR DESCRIPTION
Fixed the Display Name (topic) being added to the end of the input‑paths list; it should always be the first item. 
Added manual sorting when displaying the generated inputs in case the order of keys in the object changes during processing, since we cannot rely on field order.