### PR TITLE
Juke returns empty generation result #367

### DIFF
--- a/src/main/resources/assets/components/dialog/chat/AssistantMessagePlaceholder/AssistantMessagePlaceholder.tsx
+++ b/src/main/resources/assets/components/dialog/chat/AssistantMessagePlaceholder/AssistantMessagePlaceholder.tsx
@@ -30,8 +30,10 @@ export default function AssistantMessagePlaceholder({content}: Props): React.Rea
     const {t} = useTranslation();
     const fieldDescriptors = useStore($fieldDescriptors);
 
-    const analyzedFieldsDescriptors: FieldDescriptor[] = Object.keys(content.analysisResult)
-        .map(path => fieldDescriptors.find(descriptor => descriptor.name === path))
+    const analyzedFieldsDescriptors: FieldDescriptor[] = Object.entries(content.analysisResult)
+        .map(([path, value]) => {
+            return value.count > 0 ? fieldDescriptors.find(({name}) => name === path) : null;
+        })
         .filter(isNonOptional);
 
     const count = analyzedFieldsDescriptors.length;

--- a/src/main/resources/assets/i18n/locales/phrases_en.json
+++ b/src/main/resources/assets/i18n/locales/phrases_en.json
@@ -54,8 +54,11 @@
     "text.error.message.update.notFound": "Sorry, something went wrong, while displaying result.",
     "text.error.response.parse": "Sorry, I couldn't parse the result correctly.",
     "text.error.response.unexpected": "Sorry, I couldn't generate the result correctly.",
-    "text.error.analysis.incorrect": "Sorry, I couldn't analyze your request correctly.",
-    "text.error.generation.incorrect": "Sorry, I couldn't generate result for your request correctly.",
+    "text.error.analysis.wrongType": "Sorry, I couldn't process your request correctly. Please try again.",
+    "text.error.analysis.empty": "Sorry, I couldn't identify which fields to update. Please try rephrasing your request.",
+    "text.error.generation.wrongType": "Sorry, I couldn't create a proper response to your request. Please try again.",
+    "text.error.generation.incorrect": "Sorry, I created a response in an unexpected format. Please try rephrasing your request.",
+    "text.error.generation.empty": "Sorry, I couldn't generate content for the fields you mentioned. Please try rephrasing your request.",
     "text.mentions.notFound": "No editable inputs found",
     "text.error.license.missing": "No valid license found. Please contact your administrator",
     "text.error.license.expired": "License expired. Please contact your administrator."

--- a/src/main/resources/assets/stores/chat.ts
+++ b/src/main/resources/assets/stores/chat.ts
@@ -394,11 +394,17 @@ function getErrorMessageByCode(code: number): string {
         case ERRORS.MODEL_UNEXPECTED.code:
             return t('text.error.response.unexpected');
         case ERRORS.MODEL_ANALYSIS_PARSE_FAILED.code:
-        case ERRORS.MODEL_ANALYSIS_INCORRECT.code:
-            return t('text.error.analysis.incorrect');
+        case ERRORS.MODEL_ANALYSIS_WRONG_TYPE.code:
+            return t('text.error.analysis.wrongType');
+        case ERRORS.MODEL_ANALYSIS_EMPTY.code:
+            return t('text.error.analysis.empty');
         case ERRORS.MODEL_GENERATION_PARSE_FAILED.code:
+        case ERRORS.MODEL_GENERATION_WRONG_TYPE.code:
+            return t('text.error.generation.wrongType');
         case ERRORS.MODEL_GENERATION_INCORRECT.code:
             return t('text.error.generation.incorrect');
+        case ERRORS.MODEL_GENERATION_EMPTY.code:
+            return t('text.error.generation.empty');
         default:
             return t('text.error.rest.unknown', {code});
     }

--- a/src/main/resources/lib/flow/analyze.ts
+++ b/src/main/resources/lib/flow/analyze.ts
@@ -73,11 +73,11 @@ function parseAnalysisResult(textResult: string, allowedFields: string[]): Try<R
     try {
         const result: unknown = JSON.parse(cleanBackticks(textResult));
         if (!isObject(result)) {
-            return [null, ERRORS.MODEL_ANALYSIS_INCORRECT];
+            return [null, ERRORS.MODEL_ANALYSIS_WRONG_TYPE];
         }
         const cleaned = fixEntries(result, allowedFields);
         if (Object.keys(cleaned).length === 0) {
-            return [null, ERRORS.MODEL_ANALYSIS_INCORRECT.withMsg('No fields found in the analysis result.')];
+            return [null, ERRORS.MODEL_ANALYSIS_EMPTY];
         }
         return [cleaned, null];
     } catch (err) {

--- a/src/main/resources/lib/flow/generate.test.ts
+++ b/src/main/resources/lib/flow/generate.test.ts
@@ -1,0 +1,72 @@
+import {parseEntryValue} from './generate';
+
+jest.mock('/lib/http-client', () => ({
+    request: jest.fn(),
+}));
+
+describe('parseEntryValue', () => {
+    it('should return string value as is', () => {
+        expect(parseEntryValue('hello')).toEqual('hello');
+    });
+
+    it('should return string array as is', () => {
+        expect(parseEntryValue(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should stringify non-string elements in an array', () => {
+        expect(parseEntryValue(['a', 1, true, null, {x: 1}])).toEqual(['a', '1', 'true', 'null', '{"x":1}']);
+    });
+
+    it('should extract values from object with string values', () => {
+        expect(parseEntryValue({key1: 'val1', key2: 'val2'})).toEqual(['val1', 'val2']);
+    });
+
+    it('should flatten and concatenate values from object with string array values', () => {
+        expect(parseEntryValue({key1: ['a', 'b'], key2: ['c']})).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should extract values from object with {value: string} values', () => {
+        expect(parseEntryValue({key1: {value: 'val1'}, key2: {value: 'val2'}})).toEqual(['val1', 'val2']);
+    });
+
+    it('should handle object with a single value property', () => {
+        expect(parseEntryValue({value: 'single'})).toEqual('single');
+    });
+
+    it('should return null for objects not matching specific structures', () => {
+        expect(parseEntryValue({a: 1, b: {c: 2}})).toBeNull();
+        expect(parseEntryValue({key1: {val: 'v1'}, key2: {val: 'v2'}})).toBeNull();
+        expect(parseEntryValue({key1: ['a'], key2: 'b'})).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+        expect(parseEntryValue(null)).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+        expect(parseEntryValue(undefined)).toBeNull();
+    });
+
+    it('should return string for numbers', () => {
+        expect(parseEntryValue(123)).toEqual('123');
+        expect(parseEntryValue(123.45)).toEqual('123.45');
+    });
+
+    it('should return string for booleans', () => {
+        expect(parseEntryValue(true)).toEqual('true');
+        expect(parseEntryValue(false)).toEqual('false');
+    });
+
+    it('should handle empty array', () => {
+        expect(parseEntryValue([])).toBeNull();
+    });
+
+    it('should return null for empty object', () => {
+        expect(parseEntryValue({})).toBeNull();
+    });
+
+    it('should return null for object with mixed valid/invalid array elements for string[] case', () => {
+        const input = {key1: ['a', 1], key2: [true]};
+        expect(parseEntryValue(input)).toBeNull();
+    });
+});

--- a/src/main/resources/lib/utils/objects.ts
+++ b/src/main/resources/lib/utils/objects.ts
@@ -13,3 +13,24 @@ export function find<T>(
         }
     }
 }
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        Object.getPrototypeOf(value) === Object.prototype
+    );
+}
+
+export function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
+export function isPrimitive(value: unknown): value is string | number | boolean {
+    return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+export function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every(isString);
+}

--- a/src/main/resources/shared/errors.ts
+++ b/src/main/resources/shared/errors.ts
@@ -48,9 +48,12 @@ export const ERRORS = {
     MODEL_SPII: err(4004, 'Generation was stopped, because of Sensitive Personally Identifiable Information.'),
     // Model (Flow) Errors 4100
     MODEL_ANALYSIS_PARSE_FAILED: err(4100, 'Failed to parse analysis result.'),
-    MODEL_ANALYSIS_INCORRECT: err(4101, 'Analysis result has incorrect format.'),
-    MODEL_GENERATION_PARSE_FAILED: err(4102, 'Failed to parse generation result.'),
-    MODEL_GENERATION_INCORRECT: err(4103, 'Generation result has incorrect format.'),
+    MODEL_ANALYSIS_WRONG_TYPE: err(4101, 'Analysis result is not an object.'),
+    MODEL_ANALYSIS_EMPTY: err(4102, 'Analysis result is empty.'),
+    MODEL_GENERATION_PARSE_FAILED: err(4110, 'Failed to parse generation result.'),
+    MODEL_GENERATION_WRONG_TYPE: err(4111, 'Generation result is not an object.'),
+    MODEL_GENERATION_INCORRECT: err(4112, 'Generation result object has incorrect structure.'),
+    MODEL_GENERATION_EMPTY: err(4113, 'Generation result is empty.'),
 
     // Google Errors 5000
     GOOGLE_SAK_MISSING: err(5000, 'Google Service Account Key is missing or invalid.'),


### PR DESCRIPTION
Added clearer error messages for invalid analysis and generation to better inform the user. 
Introduced a function to normalize the generation result if it's in an incorrect format. 
Updated processing messages to omit reference-only fields with zero count.