### PR TITLE
Generation result is not checked for invalid fields #381

### DIFF
--- a/src/main/resources/assets/components/dialog/chat/AssistantMessageList/AssistantMessageList.tsx
+++ b/src/main/resources/assets/components/dialog/chat/AssistantMessageList/AssistantMessageList.tsx
@@ -1,4 +1,5 @@
 import {useStore} from '@nanostores/react';
+import {t} from 'i18next';
 import {useEffect, useMemo, useRef} from 'react';
 import {twJoin} from 'tailwind-merge';
 
@@ -6,6 +7,7 @@ import {SPECIAL_NAMES} from '../../../../../shared/enums';
 import {messageContentToValues} from '../../../../common/messages';
 import {$fieldDescriptors, $orderedPaths} from '../../../../stores/data';
 import {ModelChatMessageContent} from '../../../../stores/data/ChatMessage';
+import {MessageItem} from '../../../../stores/data/MessageItems';
 import CommonItem from '../items/CommonItem/CommonItem';
 import ElementItem from '../items/ElementItem/ElementItem';
 
@@ -27,10 +29,12 @@ export function AssistantMessageList({messageId, content, last}: Props): React.R
         }
     }, [ref, last]);
 
-    const sortedEntries = useMemo(() => {
+    const sortedEntries = useMemo((): [string, MessageItem][] => {
+        const descriptorNames = fieldDescriptors.map(descriptor => descriptor.name);
+
         const entries = Object.entries(messageContentToValues(content));
         const commonEntries = entries.filter(([key]) => key === SPECIAL_NAMES.common);
-        const elementEntries = entries.filter(([key]) => key !== SPECIAL_NAMES.common);
+        const elementEntries = entries.filter(([key]) => descriptorNames.includes(key));
 
         elementEntries.sort((a, b) => {
             const indexA = orderedPaths.indexOf(a[0]);
@@ -47,7 +51,9 @@ export function AssistantMessageList({messageId, content, last}: Props): React.R
             return indexA - indexB;
         });
 
-        return [...commonEntries, ...elementEntries];
+        const sortedEntries = [...commonEntries, ...elementEntries];
+
+        return sortedEntries.length > 0 ? sortedEntries : [[SPECIAL_NAMES.common, t('field.error.entries.empty')]];
     }, [content, orderedPaths]);
 
     return (

--- a/src/main/resources/assets/i18n/locales/phrases_en.json
+++ b/src/main/resources/assets/i18n/locales/phrases_en.json
@@ -23,6 +23,7 @@
     "field.message.assistant.placeholder.common": "Thinking on your request...",
     "field.message.assistant.placeholder.single": "Creating suggestion for {{name}}...",
     "field.message.assistant.placeholder.multiple": "Creating suggestions for {{name}} and {{count}} more...",
+    "field.error.entries.empty": "Hmm, something doesn’t match up with your request. Could you rephrase and try again?",
     "text.greeting.first": "Hi, I’m Juke, your AI assistant.",
     "text.greeting.recurring.morning": "Good morning, {{name}}. How can I help you?",
     "text.greeting.recurring.afternoon": "Good afternoon, {{name}}. How can I help you?",

--- a/src/main/resources/lib/flow/analyze.test.ts
+++ b/src/main/resources/lib/flow/analyze.test.ts
@@ -6,24 +6,24 @@ jest.mock('/lib/http-client', () => ({
 }));
 
 describe('fixEntries', () => {
-    const allowedFields = ['field1', 'field2', 'field3', SPECIAL_NAMES.topic, SPECIAL_NAMES.common];
+    const allowedFields = ['/field1', '/field2', '/field3', `/${SPECIAL_NAMES.topic}`, SPECIAL_NAMES.common];
 
     it('should return same object entries', () => {
         const input = {
-            field1: {
+            '/field1': {
                 task: 'some task',
                 count: 1,
                 language: 'en',
             },
-            field2: {
+            '/field2': {
                 task: 'another task',
                 count: 3,
                 language: 'es',
             },
-            field3: {
+            '/field3': {
                 count: 0,
             },
-            [SPECIAL_NAMES.topic]: {
+            [`/${SPECIAL_NAMES.topic}`]: {
                 task: 'some topic task',
                 count: 2,
                 language: 'en',
@@ -40,20 +40,20 @@ describe('fixEntries', () => {
 
     it('should fix reference fields', () => {
         const input = {
-            field1: {
+            '/field1': {
                 count: 1,
             },
-            field2: {
+            '/field2': {
                 count: 0,
                 language: 'en',
             },
         };
 
         const result = {
-            field1: {
+            '/field1': {
                 count: 0,
             },
-            field2: {
+            '/field2': {
                 count: 0,
             },
         };
@@ -63,24 +63,24 @@ describe('fixEntries', () => {
 
     it('should clean invalid fields', () => {
         const input = {
-            field1: {
+            '/field1': {
                 task: 'task',
                 count: 1,
                 language: 'en',
             },
-            fieldOfDifferentType: {
+            '/fieldOfDifferentType': {
                 value: 'value',
             },
-            fieldWithoutTask: {
+            '/fieldWithoutTask': {
                 language: 'en',
             },
-            [SPECIAL_NAMES.topic]: 'topic',
+            [`/${SPECIAL_NAMES.topic}`]: 'topic',
             [SPECIAL_KEYS.unclear]: {task: 'unclear task'},
             [SPECIAL_KEYS.error]: {count: 0},
         };
 
         const result = {
-            field1: {
+            '/field1': {
                 task: 'task',
                 count: 1,
                 language: 'en',
@@ -91,7 +91,7 @@ describe('fixEntries', () => {
 
     it('should return "error" special field only', () => {
         const input = {
-            field1: {
+            '/field1': {
                 task: 'some task',
                 count: 1,
                 language: 'en',
@@ -108,7 +108,7 @@ describe('fixEntries', () => {
 
     it('should return "unclear" special field only', () => {
         const input = {
-            field1: {
+            '/field1': {
                 task: 'some task',
                 count: 1,
                 language: 'en',
@@ -125,16 +125,16 @@ describe('fixEntries', () => {
 
     it('should fix count', () => {
         const input = {
-            field1: {
+            '/field1': {
                 task: 'some task',
                 count: '2',
                 language: 'no',
             },
-            field2: {
+            '/field2': {
                 task: 'another task',
                 language: 'es',
             },
-            field3: {
+            '/field3': {
                 task: 'yet another task',
                 count: 0,
                 language: 'ru',
@@ -142,17 +142,71 @@ describe('fixEntries', () => {
         };
 
         const result = {
-            field1: {
+            '/field1': {
                 task: 'some task',
                 count: 2,
                 language: 'no',
             },
-            field2: {
+            '/field2': {
                 task: 'another task',
                 count: 1,
                 language: 'es',
             },
-            field3: {
+            '/field3': {
+                task: 'yet another task',
+                count: 1,
+                language: 'ru',
+            },
+        };
+
+        expect(fixEntries(input, allowedFields)).toEqual(result);
+    });
+
+    it('should fix allowed fields and drop invalid fields', () => {
+        const input = {
+            field1: {
+                task: 'task 1',
+                count: '2',
+                language: 'en',
+            },
+            '/field2': {
+                task: 'task 2',
+                count: '2',
+                language: 'by',
+            },
+            '/wrong/field': {
+                task: 'some task',
+                count: '2',
+                language: 'no',
+            },
+            [SPECIAL_NAMES.topic]: {
+                task: 'another task',
+                language: 'es',
+            },
+            [SPECIAL_NAMES.common]: {
+                task: 'yet another task',
+                count: 1,
+                language: 'ru',
+            },
+        };
+
+        const result = {
+            '/field1': {
+                task: 'task 1',
+                count: 2,
+                language: 'en',
+            },
+            '/field2': {
+                task: 'task 2',
+                count: 2,
+                language: 'by',
+            },
+            [`/${SPECIAL_NAMES.topic}`]: {
+                task: 'another task',
+                count: 1,
+                language: 'es',
+            },
+            [SPECIAL_NAMES.common]: {
                 task: 'yet another task',
                 count: 1,
                 language: 'ru',

--- a/src/main/resources/lib/flow/generate.test.ts
+++ b/src/main/resources/lib/flow/generate.test.ts
@@ -1,4 +1,5 @@
-import {parseEntryValue} from './generate';
+import {SPECIAL_NAMES} from '../../shared/enums';
+import {fixResultFields, parseEntryValue} from './generate';
 
 jest.mock('/lib/http-client', () => ({
     request: jest.fn(),
@@ -68,5 +69,30 @@ describe('parseEntryValue', () => {
     it('should return null for object with mixed valid/invalid array elements for string[] case', () => {
         const input = {key1: ['a', 1], key2: [true]};
         expect(parseEntryValue(input)).toBeNull();
+    });
+});
+
+describe('fixResultFields', () => {
+    const allowedFields = ['/field1', '/field2/subfield', '/field3', `/${SPECIAL_NAMES.common}`];
+
+    it('should fix keys and filter out invalid entries', () => {
+        const result = {
+            '/field1': 'value1',
+            '/field2/subfield': 'value2-1',
+            'field2/subfield': 'value2-2',
+            '/field3': ['value3'],
+            [`${SPECIAL_NAMES.common}`]: 'value6',
+            nullField: null,
+            emptyArrayField: [],
+        };
+
+        const expected = {
+            '/field1': 'value1',
+            '/field2/subfield': 'value2-2',
+            '/field3': ['value3'],
+            [`/${SPECIAL_NAMES.common}`]: 'value6',
+        };
+
+        expect(fixResultFields(result, allowedFields)).toEqual(expected);
     });
 });

--- a/src/main/resources/lib/utils/fields.ts
+++ b/src/main/resources/lib/utils/fields.ts
@@ -1,0 +1,12 @@
+export function toFieldPath(path: string): string {
+    return path.startsWith('/') ? path.replace(/^\/+/, '/') : `/${path}`;
+}
+
+export function fixFieldKey(key: string, allowedFields: string[]): Optional<string> {
+    if (allowedFields.indexOf(key) >= 0) {
+        return key;
+    }
+
+    const pathKey = toFieldPath(key);
+    return allowedFields.indexOf(pathKey) >= 0 ? pathKey : null;
+}

--- a/src/main/resources/shared/prompts/generation.ts
+++ b/src/main/resources/shared/prompts/generation.ts
@@ -62,6 +62,7 @@ You MUST follow these instructions for answering:
   - Always escape any quotes in the generated text.
   - For \`${SPECIAL_NAMES.common}\` fields use HTML formatting instead of Markdown. Ensure your responses include appropriate HTML Markdown-compatible tags for emphasis (\`<em>\`, \`<strong>\`, \`<i>\`), bullet lists (\`<ul>\`, \`<ol>\`, \`<li>\`), and any other necessary formatting. Do **not** use Markdown syntax in these fields, as they will be rendered as HTML directly.
   - Prefer plain text without any HTML tags if \`${SPECIAL_NAMES.common}\` value is a monosyllabic answer, or answer, that does not require any formatting.
+  - Special field \`/${SPECIAL_NAMES.topic}\` name always starts with single \`/\` symbol.
 
 
 ### Examples: ###


### PR DESCRIPTION
Fixed UI part, that previously was filtering out unsupported fields and rendering empty list. User will now see a response from Juke. 
Updated analysis, adding attempts to normalize the fields name and make them start with a single slash. Updated generation, adding result cleaning of unsupported fields.