### PR TITLE
Display occurrence's index in the Operator's context toolbar #410

### DIFF
--- a/src/main/resources/assets/components/base/ActionButton/ActionButton.tsx
+++ b/src/main/resources/assets/components/base/ActionButton/ActionButton.tsx
@@ -10,6 +10,7 @@ type Props = {
     name?: string;
     children?: React.ReactNode;
     title?: string;
+    forceTitle?: boolean;
     icon?: IconName;
     mode?: 'icon-only' | 'icon-with-title' | 'full' | 'text-only' | 'text-with-title';
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -18,14 +19,14 @@ type Props = {
 };
 
 export default forwardRef(function ActionButton(
-    {className, disabled, name, title, icon, mode = 'full', size = 'sm', clickHandler, children}: Props,
+    {className, disabled, name, title, forceTitle, icon, mode = 'full', size = 'sm', clickHandler, children}: Props,
     ref: React.Ref<HTMLButtonElement>,
 ): React.ReactNode {
     const isEnabled = !disabled && !!clickHandler;
     const isFull = mode === 'full';
     const hasText = isFull || mode === 'text-only' || mode === 'text-with-title';
     const hasNoIcon = mode === 'text-only' || mode === 'text-with-title';
-    const hasTitle = isEnabled && (mode === 'icon-with-title' || mode === 'text-with-title');
+    const hasTitle = (isEnabled || forceTitle) && (mode === 'icon-with-title' || mode === 'text-with-title');
 
     return (
         <button

--- a/src/main/resources/assets/components/dialog/context/ContextItem/ContextItem.tsx
+++ b/src/main/resources/assets/components/dialog/context/ContextItem/ContextItem.tsx
@@ -6,7 +6,13 @@ import {setContext} from '../../../../stores/context';
 import {$allFormItemsWithPaths} from '../../../../stores/data';
 import {FormItemWithPath} from '../../../../stores/data/FormItemWithPath';
 import {Path} from '../../../../stores/data/Path';
-import {getPathLabel, isChildPath, pathsEqual, pathToString} from '../../../../stores/utils/path';
+import {
+    isChildPath,
+    pathsEqual,
+    pathToLabelAndIndex,
+    pathToPrettifiedLabel,
+    pathToString,
+} from '../../../../stores/utils/path';
 import {isInput} from '../../../../stores/utils/schema';
 import ActionButton from '../../../base/ActionButton/ActionButton';
 
@@ -25,7 +31,9 @@ export default function ContextItem({className, path, last}: Props): React.React
     const formItem = allFormItemsWithPaths.find(p => pathsEqual(p, path));
     const isEnabled = hasChildrenInputs(allFormItemsWithPaths, path) && !last && formItem != null;
 
-    const name = formItem ? getPathLabel(formItem) : '';
+    const [name, index] = (formItem && pathToLabelAndIndex(formItem)) ?? ['', undefined];
+    const titleText = (formItem && pathToPrettifiedLabel(formItem)) ?? '';
+    const title = isEnabled ? t('action.switchContextTo', {name: titleText}) : titleText;
 
     const clickHandler = isEnabled ? () => setContext(pathToString(path)) : undefined;
 
@@ -35,14 +43,17 @@ export default function ContextItem({className, path, last}: Props): React.React
                 'max-w-none min-w-0',
                 'disabled:opacity-100 enabled:hover:bg-white text-xs rounded-lg',
                 isEnabled && 'text-enonic-blue-400 hover:text-enonic-blue-500',
-                last && 'font-medium flex-shrink-0',
+                last && 'font-medium max-w-none flex-shrink-0',
                 className,
             )}
             size='sm'
             mode='text-with-title'
-            title={t('action.switchContextTo', {name})}
+            forceTitle={true}
+            title={title}
             name={name}
             clickHandler={clickHandler}
-        />
+        >
+            {index != null && <span>[{index}]</span>}
+        </ActionButton>
     );
 }

--- a/src/main/resources/assets/components/dialog/context/ContextItem/ContextItem.tsx
+++ b/src/main/resources/assets/components/dialog/context/ContextItem/ContextItem.tsx
@@ -43,7 +43,7 @@ export default function ContextItem({className, path, last}: Props): React.React
                 'max-w-none min-w-0',
                 'disabled:opacity-100 enabled:hover:bg-white text-xs rounded-lg',
                 isEnabled && 'text-enonic-blue-400 hover:text-enonic-blue-500',
-                last && 'font-medium max-w-none flex-shrink-0',
+                last && 'max-w-none flex-shrink-0',
                 className,
             )}
             size='sm'
@@ -53,7 +53,11 @@ export default function ContextItem({className, path, last}: Props): React.React
             name={name}
             clickHandler={clickHandler}
         >
-            {index != null && <span>[{index}]</span>}
+            {index != null && (
+                <span className={twJoin('pl-0.5', isEnabled ? 'text-enonic-gray-400' : 'text-enonic-gray-600')}>
+                    [{index}]
+                </span>
+            )}
         </ActionButton>
     );
 }

--- a/src/main/resources/assets/stores/data.ts
+++ b/src/main/resources/assets/stores/data.ts
@@ -21,11 +21,11 @@ import {
 } from './utils/data';
 import {getInputType} from './utils/input';
 import {
-    getPathLabel,
     isChildPath,
     isRootPath,
     pathFromString,
     pathsEqual,
+    pathToPrettifiedLabel,
     pathToPrettifiedString,
     pathToString,
 } from './utils/path';
@@ -153,7 +153,7 @@ export const $fieldDescriptors = computed($allFormItemsWithPaths, allFormItems =
             .filter((item: FormItemWithPath): item is InputWithPath => isEditableInput(item))
             .map(item => ({
                 name: pathToString(item),
-                label: getPathLabel(item),
+                label: pathToPrettifiedLabel(item),
                 displayName: pathToPrettifiedString(item),
                 type: getInputType(item),
             })),

--- a/src/main/resources/assets/stores/utils/data.ts
+++ b/src/main/resources/assets/stores/utils/data.ts
@@ -5,14 +5,14 @@ import {ContentData, PropertyArray, PropertyValue} from '../data/ContentData';
 import {FormItemSetWithPath, FormItemWithPath, FormOptionSetWithPath, InputWithPath} from '../data/FormItemWithPath';
 import {Mention} from '../data/Mention';
 import {Path, PathElement} from '../data/Path';
-import {clonePath, getPathLabel, pathToPrettifiedString, pathToString} from './path';
+import {clonePath, pathToPrettifiedLabel, pathToPrettifiedString, pathToString} from './path';
 import {isFormItemSet, isFormOptionSet, isInput} from './schema';
 
 export function pathToMention(item: FormItemWithPath): Mention {
     return {
         path: pathToString(item),
         prettified: pathToPrettifiedString(item),
-        label: getPathLabel(item),
+        label: pathToPrettifiedLabel(item),
     };
 }
 
@@ -63,11 +63,11 @@ function createPropertyPaths(
 
     const thisIterationResult: Path[] = [];
 
-    propertyArray.values.forEach((value: PropertyValue, index) => {
+    propertyArray.values.forEach((value, index, array) => {
         const newPathElement: PathElement = {
             name: propertyArray.name,
             label: pathElement.label,
-            index: index,
+            index: array.length > 1 ? index : undefined,
         };
 
         const newPath = previousIterationResult.length > 0 ? clonePath(previousIterationResult[0]) : {elements: []};

--- a/src/main/resources/assets/stores/utils/path.ts
+++ b/src/main/resources/assets/stores/utils/path.ts
@@ -41,12 +41,8 @@ export const pathFromString = (pathAsString: string): Path => {
 };
 
 export function pathToString(path: Path): string {
-    return '/' + path.elements.map(pathElementToString).join('/');
-}
-
-function pathElementToString(element: PathElement): string {
-    const text = element.name;
-    return element.index == null ? text : `${text}[${element.index}]`;
+    const elements = path.elements.map(({index, name}) => (!index ? name : `${name}[${index}]`));
+    return '/' + elements.join('/');
 }
 
 export function pathToPrettifiedLabel(path: Path): string {
@@ -75,12 +71,12 @@ export function clonePath(path: Path): Path {
 }
 
 export function pathToPrettifiedString(path: Path): string {
-    return path.elements.map(pathElementToPrettifiedString).join('/');
+    return path.elements.map(pathElementToPrettifiedString).join(' / ');
 }
 
 function pathElementToPrettifiedString(element: PathElement): string {
     const text = element.label || element.name;
-    return element.index == null ? text : `${text}[${element.index}]`;
+    return element.index == null ? text : `${text} [${element.index + 1}]`;
 }
 
 export function isChildPath(child: Path, parent: Path): boolean {

--- a/src/main/resources/assets/stores/utils/path.ts
+++ b/src/main/resources/assets/stores/utils/path.ts
@@ -46,12 +46,20 @@ export function pathToString(path: Path): string {
 
 function pathElementToString(element: PathElement): string {
     const text = element.name;
-    return element.index == undefined || element.index === 0 ? text : `${text}[${element.index}]`;
+    return element.index == null ? text : `${text}[${element.index}]`;
 }
 
-export function getPathLabel(path: Path): string {
+export function pathToPrettifiedLabel(path: Path): string {
+    const [label = '', index] = pathToLabelAndIndex(path) ?? [];
+    return index == null ? label : `${label} [${index}]`;
+}
+
+export function pathToLabelAndIndex(path: Path): Optional<[string, Optional<number>]> {
     const lastElement = path.elements.at(-1);
-    return lastElement?.label ?? lastElement?.name ?? '';
+    if (lastElement) {
+        const index = lastElement.index != null ? lastElement.index + 1 : null;
+        return [lastElement.label ?? lastElement.name, index];
+    }
 }
 
 export function clonePath(path: Path): Path {
@@ -72,7 +80,7 @@ export function pathToPrettifiedString(path: Path): string {
 
 function pathElementToPrettifiedString(element: PathElement): string {
     const text = element.label || element.name;
-    return element.index == undefined || element.index === 0 ? text : `${text}[${element.index}]`;
+    return element.index == null ? text : `${text}[${element.index}]`;
 }
 
 export function isChildPath(child: Path, parent: Path): boolean {

--- a/src/main/resources/assets/stores/utils/schema.ts
+++ b/src/main/resources/assets/stores/utils/schema.ts
@@ -39,19 +39,11 @@ export const isFormOptionSetOptionWithPath = (item: FormItemWithPath): item is F
     isFormOptionSetOption(item) && isPath(item);
 
 export function getFormItemsWithPaths(formItems: FormItem[]): FormItemWithPath[] {
-    const result: FormItemWithPath[] = [];
-    result.push(...getPathsOfMentionableItems(formItems, {elements: []}));
-    return result;
+    return getPathsOfMentionableItems(formItems, {elements: []});
 }
 
 function getPathsOfMentionableItems(formItems: FormItem[], path: Path): FormItemWithPath[] {
-    const result: FormItemWithPath[] = [];
-
-    formItems.forEach(item => {
-        result.push(...fetchFormItemPath(item, path));
-    });
-
-    return result;
+    return formItems.flatMap(item => fetchFormItemPath(item, path));
 }
 
 function fetchFormItemPath(item: FormItem, path: Path): FormItemWithPath[] {


### PR DESCRIPTION
Updated how index is calculated in Path, removing it only when there are no children elements, keeping it for 0-index elements with one or more siblings. 
Updated function to create input's label.
Moved index to a separate element in ContextItem to prevent truncation.