### PR TITLE
Take into account input's help-text #411

### DIFF
--- a/src/main/resources/assets/stores/data.ts
+++ b/src/main/resources/assets/stores/data.ts
@@ -15,6 +15,8 @@ import {Schema} from './data/Schema';
 import {
     createDisplayNameInput,
     getDataPathsToEditableItems,
+    getHelpText,
+    getParentHelpTexts,
     getPropertyArrayByPath,
     isTopicPath,
     pathToMention,
@@ -94,6 +96,22 @@ export const $orderedPaths = computed($allFormItemsWithPaths, items => {
     return items.map(item => pathToString(item));
 });
 
+const $helpTextMap = computed($allFormItemsWithPaths, items => {
+    return items.reduce(
+        (acc, item) => {
+            const path = pathToString(item);
+            const helpText = getHelpText(item);
+
+            if (helpText) {
+                acc[path] = helpText;
+            }
+
+            return acc;
+        },
+        {} as Record<string, string>,
+    );
+});
+
 //
 //* CONTEXT
 //
@@ -169,6 +187,8 @@ export function createFields(): Record<string, DataEntry> {
             type: getInputType(inputWithPath),
             schemaType: inputWithPath.Input.inputType,
             schemaLabel: inputWithPath.Input.label,
+            schemaHelpText: inputWithPath.Input.helpText,
+            parentHelpTexts: getParentHelpTexts(inputWithPath, $helpTextMap.get()),
         };
     });
 

--- a/src/main/resources/assets/stores/data/Schema.ts
+++ b/src/main/resources/assets/stores/data/Schema.ts
@@ -23,7 +23,7 @@ export type FormOptionSet = {
     FormOptionSet: FormOptionSetData;
 };
 
-export type FormOptionSetOption = FormItemNameAndLabel & FormItems;
+export type FormOptionSetOption = FormItemNameAndLabel & FormItemHelpText & FormItems;
 
 export type FormItemNameAndLabel = {
     name: string;
@@ -43,14 +43,18 @@ export type FormItemOccurrences = {
 
 export type FieldSetData = FormItemNameAndLabel & FormItems;
 
-export type FormItemSetData = FormItemNameAndLabel & FormItems & FormItemOccurrences;
+export type FormSetData = FormItemNameAndLabel & FormItemHelpText & FormItemOccurrences;
 
-export type InputData = FormItemNameAndLabel &
-    FormItemOccurrences & {
-        inputType: string;
-    };
+export type FormItemSetData = FormSetData & FormItems;
 
-export type FormOptionSetData = FormItemNameAndLabel &
-    FormItemOccurrences & {
-        options: FormOptionSetOption[];
-    };
+export type InputData = FormSetData & {
+    inputType: string;
+};
+
+export type FormItemHelpText = {
+    helpText?: string;
+};
+
+export type FormOptionSetData = FormSetData & {
+    options: FormOptionSetOption[];
+};

--- a/src/main/resources/assets/stores/utils/data.ts
+++ b/src/main/resources/assets/stores/utils/data.ts
@@ -5,7 +5,8 @@ import {ContentData, PropertyArray, PropertyValue} from '../data/ContentData';
 import {FormItemSetWithPath, FormItemWithPath, FormOptionSetWithPath, InputWithPath} from '../data/FormItemWithPath';
 import {Mention} from '../data/Mention';
 import {Path, PathElement} from '../data/Path';
-import {clonePath, pathToPrettifiedLabel, pathToPrettifiedString, pathToString} from './path';
+import {FormItem} from '../data/Schema';
+import {clonePath, getParentPath, pathToPrettifiedLabel, pathToPrettifiedString, pathToString} from './path';
 import {isFormItemSet, isFormOptionSet, isInput} from './schema';
 
 export function pathToMention(item: FormItemWithPath): Mention {
@@ -133,4 +134,32 @@ export function createDisplayNameInput(): InputWithPath {
 
 export function isTopicPath(path: Path): boolean {
     return pathToString(path) === `/${SPECIAL_NAMES.topic}`;
+}
+
+export function getHelpText(item: FormItem): Optional<string> {
+    if (isInput(item)) {
+        return item.Input.helpText;
+    } else if (isFormItemSet(item)) {
+        return item.FormItemSet.helpText;
+    } else if (isFormOptionSet(item)) {
+        return item.FormOptionSet.helpText;
+    }
+
+    return undefined;
+}
+
+export function getParentHelpTexts(path: Path, helpTextMap: Record<string, string>): string[] | undefined {
+    const texts: string[] = [];
+
+    let parentPath = getParentPath(path);
+    while (parentPath) {
+        const helpText = helpTextMap[pathToString(parentPath)];
+        if (helpText) {
+            texts.push(helpText);
+        }
+
+        parentPath = getParentPath(parentPath);
+    }
+
+    return texts.length > 0 ? texts : undefined;
 }

--- a/src/main/resources/shared/data/DataEntry.ts
+++ b/src/main/resources/shared/data/DataEntry.ts
@@ -4,6 +4,7 @@ export type DataEntry = {
     schemaType: string;
     schemaLabel: string;
     schemaHelpText?: string;
+    parentHelpTexts?: string[];
 };
 
 export type DataEntryType = 'text' | 'html';

--- a/src/main/resources/shared/prompts/analysis.ts
+++ b/src/main/resources/shared/prompts/analysis.ts
@@ -67,6 +67,7 @@ You MUST follow the instructions for answering:
       - DO NOT apply apply user's request to the task text, make it a part of the task instead.
       - Include any related instructions from "Instructions" section into the task.
       - DO NOT include information about variants to this value of this key, use it in \`"count"\` key instead.
+      - When formulating the task, you MUST incorporate contextual information from the field's \`schemaHelpText\` and any relevant \`parentHelpTexts\` (from the "Content" JSON). For example, if \`schemaHelpText\` for a field indicates "This is a product tagline," and the user requests "make it punchier," your task should be something like: "Rewrite the product tagline to be punchier."
     - \`"count"\`: The number of variants that needs to be generated for the field.
       - If user did not ask to modify this field, set this value to 0.
       - If user asked to modify this field, but did not specified number of variants, set this value to 1.
@@ -92,6 +93,8 @@ You MUST follow the instructions for answering:
   - \`"value"\`: The current text in the field.
   - \`"type"\`: Either \`"text"\` or \`"html"\`. If \`"html"\`, the field may contain Markdown-compatible HTML tags.
   - \`"schemaLabel"\`: The display name of the field, which may hint at its intended content.
+  - \`"schemaHelpText"\`: Optional help text written by the user to understand purpose of the field.
+  - \`"parentHelpTexts"\`: Optional help texts for a better understanding of the nesting of the field and its purpose in the content. May include unrelated information.
 
 ### Examples ###
 
@@ -156,14 +159,14 @@ Move text from {{/article/intro}} to {{/article/main}}. Place a proper Latin quo
 # Content
 {
   "/${SPECIAL_NAMES.topic}": "Roman Empire",
-  "/article/intro": {"value":"The Roman Empire was one of the most powerful in history, known for its vast territorial holdings.","type":"text","schemaType":"TextArea","schemaLabel":"Introduction"},
+  "/article/intro": {"value":"The Roman Empire was one of the most powerful in history, known for its vast territorial holdings.","type":"text","schemaType":"TextArea","schemaLabel":"Introduction", "schemaHelpText": "Quote from the Roman poet Horace."},
   "/article/main": {"value":"<p>The emperors and structures of <b>Rome</b> left a lasting impact on global architecture, politics, and culture.</p>","type":"html","schemaType":"TextArea","schemaLabel":"Main Part"}
 }
 \`\`\`
 
 - **Model's Response:**
 {
-  "/article/intro": {"task": "Replace text with a quote in Latin.", "count": 1, "language": "la"},
+  "/article/intro": {"task": "Replace text with a quote in Latin by Horace.", "count": 1, "language": "la"},
   "/article/main": {"task": "Keep the current text and copy the value of {{/article/intro}} to beginning.", "count": 1, "language": "en-US"}
 }
 


### PR DESCRIPTION
Added helpText property to corresponding field item types. 
Added help text from input, and it's parent to DataEntry, that is sent to server. 
Updated analysis prompt to use help text to formulate better, more natural tasks for the field.