### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -14,6 +14,9 @@ jobs:
                   repoUser: ci
                   repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
                   codecovToken: ${{ secrets.CODECOV_TOKEN }}
+                  releaseBranch: |
+                      master
+                      1.x
 
     release:
         runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ xpVersion=8.0.0-B4
 
 # Settings for publishing to a Maven repo
 group=com.enonic.app
-version=1.2.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Bumps master to the next major SNAPSHOT now that XP 8 work has landed, following the [app-booster](https://github.com/enonic/app-booster) pattern.

- `gradle.properties`: `version` `1.2.1-SNAPSHOT` → `2.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing both `master` and the new maintenance branch `1.x`

The XP 7 maintenance line continues from branch [`1.x`](https://github.com/enonic/app-ai-content-operator/tree/1.x), branched from tag `v1.2.0`.

## Test plan

- [x] `./gradlew clean build` is green locally
- [ ] CI build passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)