### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -14,6 +14,9 @@ jobs:
                   repoUser: ci
                   repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
                   codecovToken: ${{ secrets.CODECOV_TOKEN }}
+                  releaseBranch: |
+                      master
+                      1.x
 
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` on `1.x`, listing both `master` and `1.x`.
- Mirrors the shape already merged on `master`, so pushes to `1.x` are now classified as release-branch builds and trigger the release tooling.

The `enonic/release-tools/build-and-publish@master` action reads `releaseBranch:` from the workflow file on the branch being built. Without this change, the maintenance branch would never be treated as a release branch.

## Test plan

- [ ] CI run on `chore/1.x-add-release-branch` is green
- [ ] After merge, a push to `1.x` is classified as a release-branch build (release job runs when build outputs `release == 'true'`)