### PR TITLE
Add stories for placeholder and context controls #778

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,34 @@
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { themes } from 'storybook/theming';
 
+import { setPluginContext } from '@/store/host/host.utils';
+
+import type { AiPluginApi } from '@shared/ai-protocol';
 import type { Preview } from '@storybook/preact-vite';
 
 import { withI18n } from './withI18n';
 import './storybook.css';
+
+// Stub the host API so store listeners (e.g. $context.listen → getHostApi())
+// don't throw in Storybook. Without this, a single throwing listener breaks
+// nanostores' synchronous notify loop and downstream React subscribers never
+// re-render.
+const noop = (): void => {};
+const stubApi: AiPluginApi = {
+  on: () => () => {},
+  applyValue: () => false,
+  setFieldState: noop,
+  animateField: noop,
+  setContext: noop,
+  setDialogState: noop,
+  requestSave: noop,
+  notify: noop,
+};
+setPluginContext({
+  config: { wsServiceUrl: '', instructions: '' },
+  initial: { content: null, schema: null, language: null },
+  api: stubApi,
+});
 
 const isDark = globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches;
 

--- a/src/main/resources/assets/components/dialog/chat/assistant-message-placeholder/AssistantMessagePlaceholder.stories.tsx
+++ b/src/main/resources/assets/components/dialog/chat/assistant-message-placeholder/AssistantMessagePlaceholder.stories.tsx
@@ -1,0 +1,116 @@
+import { useEffect } from 'react';
+
+import { setPersistedData, setSchema } from '@/store/content';
+
+import type { ModelChatMessageContent } from '@/store/content';
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+
+import { AssistantMessagePlaceholder } from './AssistantMessagePlaceholder';
+
+const meta = {
+  title: 'ContentOperator/Dialog/Chat/AssistantMessagePlaceholder',
+  component: AssistantMessagePlaceholder,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div className="ai-content-operator text-main bg-surface-neutral w-100 rounded-lg p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AssistantMessagePlaceholder>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type PlaceholderContent = Omit<ModelChatMessageContent, 'generationResult'>;
+
+const noFieldsContent: PlaceholderContent = {
+  analysisResult: {},
+  selectedIndices: {},
+};
+
+const singleFieldContent: PlaceholderContent = {
+  analysisResult: {
+    '/displayName': { task: 'Suggest a display name.', count: 1, language: 'en' },
+  },
+  selectedIndices: {},
+};
+
+const multipleFieldsContent: PlaceholderContent = {
+  analysisResult: {
+    '/displayName': { task: 'Suggest a display name.', count: 1, language: 'en' },
+    '/description': { task: 'Suggest a description.', count: 1, language: 'en' },
+    '/tagline': { task: 'Suggest a tagline.', count: 1, language: 'en' },
+  },
+  selectedIndices: {},
+};
+
+function seedStores(): void {
+  setSchema({
+    name: 'mockSchema',
+    form: {
+      formItems: [
+        {
+          Input: {
+            name: 'displayName',
+            label: 'Display Name',
+            inputType: 'TextLine',
+            occurrences: { minimum: 0, maximum: 1 },
+          },
+        },
+        {
+          Input: {
+            name: 'description',
+            label: 'Description',
+            inputType: 'TextArea',
+            occurrences: { minimum: 0, maximum: 1 },
+          },
+        },
+        {
+          Input: {
+            name: 'tagline',
+            label: 'Tagline',
+            inputType: 'TextLine',
+            occurrences: { minimum: 0, maximum: 1 },
+          },
+        },
+      ],
+    },
+  });
+  setPersistedData({
+    contentId: 'mock-id',
+    contentPath: '/mock',
+    fields: [
+      { name: 'displayName', type: 'String', values: [{ v: '' }] },
+      { name: 'description', type: 'String', values: [{ v: '' }] },
+      { name: 'tagline', type: 'String', values: [{ v: '' }] },
+    ],
+    topic: 'Mock topic',
+  });
+}
+
+const PlaceholderStory = ({ content }: { content: PlaceholderContent }): React.ReactNode => {
+  useEffect(() => {
+    seedStores();
+  }, []);
+  return <AssistantMessagePlaceholder content={content} />;
+};
+
+export const NoFields: Story = {
+  name: 'Examples / No Fields',
+  args: { content: noFieldsContent },
+  render: (args) => <PlaceholderStory content={args.content} />,
+};
+
+export const SingleField: Story = {
+  name: 'Examples / Single Field',
+  args: { content: singleFieldContent },
+  render: (args) => <PlaceholderStory content={args.content} />,
+};
+
+export const MultipleFields: Story = {
+  name: 'Examples / Multiple Fields',
+  args: { content: multipleFieldsContent },
+  render: (args) => <PlaceholderStory content={args.content} />,
+};

--- a/src/main/resources/assets/components/dialog/chat/assistant-message-placeholder/AssistantMessagePlaceholder.tsx
+++ b/src/main/resources/assets/components/dialog/chat/assistant-message-placeholder/AssistantMessagePlaceholder.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@enonic/ui';
+import { Button, cn } from '@enonic/ui';
 import { useStore } from '@nanostores/react';
-import { ChevronDown, ChevronRight, LoaderCircle } from 'lucide-react';
+import { ChevronRight, LoaderCircle } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -63,20 +63,19 @@ export const AssistantMessagePlaceholder = ({
         onClick={() => setExpanded(!expanded)}
         className={cn(
           ASSISTANT_MESSAGE_PLACEHOLDER_NAME,
-          'inline-flex items-center justify-start',
+          'inline-flex items-center justify-start gap-1',
           '-mx-2 min-h-8 rounded px-2 py-1.5',
           'text-main bg-surface-neutral text-sm',
-          'enabled:hover:bg-surface-neutral-hover',
+          'enabled:hover:bg-surface-neutral-hover enabled:cursor-pointer',
           'disabled:opacity-50',
           !hasFields && 'enabled:hover:bg-surface-neutral enabled:hover:cursor-default',
         )}
       >
-        {hasFields &&
-          (expanded ? (
-            <ChevronDown className="size-3 shrink-0" />
-          ) : (
-            <ChevronRight className="size-3 shrink-0" />
-          ))}
+        {hasFields && (
+          <ChevronRight
+            className={cn('size-3 shrink-0 transition-transform', expanded && 'rotate-90')}
+          />
+        )}
         <span className="bg-gradient-middle bg-text-gradient-size to-muted animate-move-gradient from-main bg-clip-text text-left text-sm text-transparent">
           {t(getPlaceholderMessage(count), {
             name: analyzedFieldsDescriptors.at(0)?.label,
@@ -84,17 +83,19 @@ export const AssistantMessagePlaceholder = ({
           })}
         </span>
       </button>
-      <ul className={cn('flex flex-col gap-1 pl-6', !expanded && 'hidden')}>
+      <ul className={cn('flex flex-col gap-1 pl-6 mt-1', !expanded && 'hidden')}>
         {analyzedFieldsDescriptors.map(({ name, label, displayName }) => (
-          <li key={name} className="flex items-center gap-0.5">
-            <button
-              className="text-info inline-flex cursor-pointer items-center truncate rounded px-1 align-baseline font-semibold"
+          <li key={name}>
+            <Button
+              size="sm"
+              endIcon={LoaderCircle}
+              endIconClassName="text-subtle size-3 animate-spin"
+              className="text-info flex h-6 leading-6 px-2 -ml-2 text-sm max-w-full truncate"
               title={displayName}
               onClick={() => scrollToField(name)}
             >
-              <span className="text-xs">{label}</span>
-            </button>
-            <LoaderCircle className="text-subtle size-4 animate-spin" />
+              <span className="truncate">{label}</span>
+            </Button>
           </li>
         ))}
       </ul>

--- a/src/main/resources/assets/components/dialog/chat/assistant-message/AssistantMessage.tsx
+++ b/src/main/resources/assets/components/dialog/chat/assistant-message/AssistantMessage.tsx
@@ -40,13 +40,13 @@ export const AssistantMessage = ({
           <JukeIcon className="size-full" />
         </Avatar.Fallback>
       </Avatar.Root>
-      <article className="flex flex-1 flex-col gap-5 text-sm text-pretty">
+      <article className="flex flex-1 flex-col text-sm text-pretty">
         {isGenerating ? (
           <AssistantMessagePlaceholder content={content} />
         ) : (
           <>
             <AssistantMessageList messageId={messageId} content={content} last={last} />
-            <ResponseControls message={message} last={last} />
+            <ResponseControls className='mt-5' message={message} last={last} />
           </>
         )}
       </article>

--- a/src/main/resources/assets/components/dialog/context/context-controls/ContextControls.stories.tsx
+++ b/src/main/resources/assets/components/dialog/context/context-controls/ContextControls.stories.tsx
@@ -1,0 +1,220 @@
+import { cn } from '@enonic/ui';
+import { useEffect } from 'react';
+
+import { setPersistedData, setSchema } from '@/store/content';
+import { resetContext, setContext } from '@/store/context';
+
+import type { Meta, StoryObj } from '@storybook/preact-vite';
+
+import { ContextControls } from './ContextControls';
+
+const meta = {
+  title: 'ContentOperator/Dialog/Context/ContextControls',
+  component: ContextControls,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof ContextControls>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const longLabel =
+  'A really really long display name that definitely should get truncated with an ellipsis at the end';
+
+const wrapperClasses =
+  'ai-content-operator text-main bg-surface-primary flex flex-col rounded-lg p-5';
+
+function seedSingleEntry(): () => void {
+  setSchema({
+    name: 'mockSchema',
+    form: {
+      formItems: [
+        {
+          Input: {
+            name: 'displayName',
+            label: 'Display Name',
+            inputType: 'TextLine',
+            occurrences: { minimum: 0, maximum: 1 },
+          },
+        },
+      ],
+    },
+  });
+  setPersistedData({
+    contentId: 'mock-id',
+    contentPath: '/mock',
+    fields: [{ name: 'displayName', type: 'String', values: [{ v: '' }] }],
+    topic: 'Mock topic',
+  });
+  setContext('/displayName');
+  return resetContext;
+}
+
+function seedMultipleEntries(): () => void {
+  setSchema({
+    name: 'mockSchema',
+    form: {
+      formItems: [
+        {
+          FormItemSet: {
+            name: 'article',
+            label: 'Article',
+            occurrences: { minimum: 0, maximum: 1 },
+            items: [
+              {
+                FormItemSet: {
+                  name: 'intro',
+                  label: 'Intro',
+                  occurrences: { minimum: 0, maximum: 1 },
+                  items: [
+                    {
+                      Input: {
+                        name: 'title',
+                        label: 'Title',
+                        inputType: 'TextLine',
+                        occurrences: { minimum: 0, maximum: 1 },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+  setPersistedData({
+    contentId: 'mock-id',
+    contentPath: '/mock',
+    fields: [
+      {
+        name: 'article',
+        type: 'PropertySet',
+        values: [
+          {
+            set: [
+              {
+                name: 'intro',
+                type: 'PropertySet',
+                values: [
+                  {
+                    set: [{ name: 'title', type: 'String', values: [{ v: '' }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    topic: 'Mock topic',
+  });
+  setContext('/article/intro/title');
+  return resetContext;
+}
+
+function seedLongLabels(): () => void {
+  setSchema({
+    name: 'mockSchema',
+    form: {
+      formItems: [
+        {
+          FormItemSet: {
+            name: 'outerSection',
+            label: longLabel,
+            occurrences: { minimum: 0, maximum: 1 },
+            items: [
+              {
+                FormItemSet: {
+                  name: 'innerSection',
+                  label: longLabel,
+                  occurrences: { minimum: 0, maximum: 1 },
+                  items: [
+                    {
+                      Input: {
+                        name: 'title',
+                        label: 'Title',
+                        inputType: 'TextLine',
+                        occurrences: { minimum: 0, maximum: 1 },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+  setPersistedData({
+    contentId: 'mock-id',
+    contentPath: '/mock',
+    fields: [
+      {
+        name: 'outerSection',
+        type: 'PropertySet',
+        values: [
+          {
+            set: [
+              {
+                name: 'innerSection',
+                type: 'PropertySet',
+                values: [
+                  {
+                    set: [{ name: 'title', type: 'String', values: [{ v: '' }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    topic: 'Mock topic',
+  });
+  setContext('/outerSection/innerSection/title');
+  return resetContext;
+}
+
+const SingleEntryStory = (): React.ReactNode => {
+  useEffect(() => seedSingleEntry(), []);
+  return (
+    <div className={cn(wrapperClasses, 'w-100')}>
+      <ContextControls />
+    </div>
+  );
+};
+
+const MultipleEntriesStory = (): React.ReactNode => {
+  useEffect(() => seedMultipleEntries(), []);
+  return (
+    <div className={cn(wrapperClasses, 'w-100')}>
+      <ContextControls />
+    </div>
+  );
+};
+
+const LongLabelsStory = (): React.ReactNode => {
+  useEffect(() => seedLongLabels(), []);
+  return (
+    <div className={cn(wrapperClasses, 'w-100')}>
+      <ContextControls />
+    </div>
+  );
+};
+
+export const SingleEntry: Story = {
+  name: 'Examples / Single Entry',
+  render: () => <SingleEntryStory />,
+};
+
+export const MultipleEntries: Story = {
+  name: 'Examples / Multiple Entries',
+  render: () => <MultipleEntriesStory />,
+};
+
+export const LongLabelsTruncated: Story = {
+  name: 'Features / Long Labels Truncated',
+  render: () => <LongLabelsStory />,
+};

--- a/src/main/resources/assets/components/dialog/context/context-controls/ContextControls.tsx
+++ b/src/main/resources/assets/components/dialog/context/context-controls/ContextControls.tsx
@@ -23,11 +23,11 @@ function createItems(paths: Path[]): React.ReactNode[] {
     return isLast
       ? [<ContextItem key={`${key}-item-last`} path={path} last={isLast} />]
       : [
-          <ContextItem key={`${key}-item`} path={path} last={isLast} />,
-          <span key={`${key}-sep`} className="text-subtle shrink-0 cursor-default select-none">
-            /
-          </span>,
-        ];
+        <ContextItem key={`${key}-item`} path={path} last={isLast} />,
+        <span key={`${key}-sep`} className="text-subtle shrink-0 cursor-default select-none">
+          /
+        </span>,
+      ];
   });
 }
 
@@ -41,7 +41,7 @@ export const ContextControls = ({ className }: ContextControlsProps): React.Reac
       data-component={CONTEXT_CONTROLS_NAME}
       className={cn(
         CONTEXT_CONTROLS_NAME,
-        'flex items-center justify-start gap-0.5',
+        'flex items-center justify-start gap-2',
         'text-xs',
         'overflow-hidden',
         'transition-all duration-150 ease-in-out',
@@ -54,12 +54,13 @@ export const ContextControls = ({ className }: ContextControlsProps): React.Reac
         variant="filled"
         size="sm"
         endIcon={X}
+        endIconClassName='shrink-0'
         iconSize="md"
         aria-label={t('action.resetContext')}
-        className="ml-auto"
+        className="ml-auto h-7"
         onClick={resetContext}
       >
-        {t('action.resetContext')}
+        <span className="truncate">{t('action.resetContext')}</span>
       </Button>
     </div>
   );

--- a/src/main/resources/assets/components/dialog/context/context-item/ContextItem.tsx
+++ b/src/main/resources/assets/components/dialog/context/context-item/ContextItem.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@enonic/ui';
+import { Button, cn, Tooltip } from '@enonic/ui';
 import { useStore } from '@nanostores/react';
 import { t } from 'i18next';
 
@@ -39,28 +39,29 @@ export const ContextItem = ({ className, path, last }: ContextItemProps): React.
   const onClick = isEnabled ? () => setContext(pathToString(path)) : undefined;
 
   return (
-    <button
-      type="button"
-      data-component={CONTEXT_ITEM_NAME}
-      disabled={!isEnabled}
-      onClick={onClick}
-      title={title}
-      className={cn(
-        CONTEXT_ITEM_NAME,
-        'inline-flex items-center justify-center',
-        'h-6 max-w-40 min-w-0 truncate rounded-lg px-1.5',
-        'text-main text-sm',
-        'enabled:hover:bg-surface-neutral disabled:opacity-100',
-        isEnabled && 'text-info hover:text-info-rev',
-        last && 'max-w-none shrink-0',
-        className,
-      )}
-    >
-      <span className="truncate">{name}</span>
-      {index != null && (
-        <span className={cn('pl-0.5', !isEnabled && 'font-semibold')}>[{index}]</span>
-      )}
-    </button>
+    <Tooltip side="top" delay={500} value={title} asChild>
+      <Button
+        size="sm"
+        variant="filled"
+        data-component={CONTEXT_ITEM_NAME}
+        disabled={!isEnabled}
+        onClick={onClick}
+        className={cn(
+          CONTEXT_ITEM_NAME,
+          'inline-flex items-center justify-center',
+          'h-7 max-w-40 min-w-0  px-2.5',
+          'text-sm disabled:text-main',
+          last && 'max-w-none shrink-0',
+          'disabled:pointer-auto disabled:select-text disabled:opacity-100 disabled:font-normal',
+          className,
+        )}
+      >
+        <span className="truncate">{name}</span>
+        {index != null && (
+          <span className={cn('pl-0.5', !isEnabled && 'font-semibold')}>[{index}]</span>
+        )}
+      </Button>
+    </Tooltip>
   );
 };
 ContextItem.displayName = CONTEXT_ITEM_NAME;


### PR DESCRIPTION
## Changes

- Added `AssistantMessagePlaceholder.stories.tsx` — no-fields, single-field, multiple-fields.
- Added `ContextControls.stories.tsx` — single entry, multiple entries, long-labels truncation.
- Stubbed host API in `.storybook/preview.tsx` so `$context.listen` calling `getHostApi()` doesn't break nanostores' synchronous notify loop in Storybook.
- Switched `ContextItem` to the shared `Button`; refreshed placeholder chevron toggle, field-list buttons, and reset button styling.

Closes #778

<sub>*Drafted with AI assistance*</sub>
