### PR TITLE
Fix loading message and input focus when reopening the dialog #785

### DIFF
--- a/src/main/resources/assets/components/dialog/assistant-dialog/AssistantDialog.tsx
+++ b/src/main/resources/assets/components/dialog/assistant-dialog/AssistantDialog.tsx
@@ -95,6 +95,8 @@ export const AssistantDialog = ({ className = '' }: AssistantDialogProps): React
           ref={contentRef}
           data-component={ASSISTANT_DIALOG_NAME}
           modal={false}
+          // ! PromptArea owns focus-on-open; let Radix's autofocus not contend for it
+          onOpenAutoFocus={(event) => event.preventDefault()}
           className={cn(
             ASSISTANT_DIALOG_NAME,
             'group/resize',

--- a/src/main/resources/assets/components/dialog/chat/chat-thread/ChatThread.tsx
+++ b/src/main/resources/assets/components/dialog/chat/chat-thread/ChatThread.tsx
@@ -3,8 +3,8 @@ import { useStore } from '@nanostores/react';
 import { useEffect, useRef } from 'react';
 
 import { $history } from '@/store/chat';
-import { $initialized, $licenseState } from '@/store/license';
-import { $busyAnalyzing, $websocket } from '@/store/websocket';
+import { $initialized } from '@/store/license';
+import { $busyAnalyzing } from '@/store/websocket';
 
 import type { ChatMessage } from '@/store/content';
 
@@ -38,10 +38,8 @@ function createMessages(history: ChatMessage[], isLoading: boolean): React.React
 
 export const ChatThread = ({ className = '' }: ChatThreadProps): React.ReactNode => {
   const isInitialized = useStore($initialized);
-  const licenseState = useStore($licenseState);
-  const isConnecting = useStore($websocket, { keys: ['state'] }).state === 'connecting';
   const isBusyAnalyzing = useStore($busyAnalyzing);
-  const isLoading = !isInitialized || !licenseState || isConnecting || isBusyAnalyzing;
+  const isLoading = !isInitialized || isBusyAnalyzing;
 
   const history = useStore($history);
   const count = history.length;


### PR DESCRIPTION
## Changes

- Gate the `ChatThread` loading message on `isInitialized` and `isBusyAnalyzing` only, so the WebSocket reconnect that fires on every reopen no longer re-shows "Thinking…" beneath the persisted greeting. The dropped `isConnecting`/`licenseState` terms were redundant on first boot (already covered by `isInitialized`) and only re-fired on transparent reconnects.
- Prevent Radix's default dialog autofocus via `onOpenAutoFocus` so `PromptArea` reliably focuses the editor on open instead of contending with the dialog content.

Closes #785

<sub>*Drafted with AI assistance*</sub>
