### PR TITLE
Dialog doesn't reset context after input loses focus #783

### DIFF
--- a/src/main/resources/assets/store/dialog/dialog.utils.ts
+++ b/src/main/resources/assets/store/dialog/dialog.utils.ts
@@ -1,3 +1,4 @@
+import { resetContext } from '@/store/context';
 import { getHostApi } from '@/store/host';
 
 import { $dialog } from './dialog.store';
@@ -7,6 +8,9 @@ export const setDialogHidden = (hidden: boolean): void => {
   if (isStateChanged) {
     getHostApi().setDialogState(!hidden);
     $dialog.setKey('hidden', hidden);
+    if (hidden) {
+      resetContext();
+    }
   }
 };
 


### PR DESCRIPTION
Reset the context store when the Operator dialog closes, so a focused field's context no longer persists across a close/reopen.

The host sets context on field focus but never clears it on blur, and the dialog gets no signal for a host-field blur — so the previously focused field stayed in context after the dialog was reopened (even on a different tab). Resetting on close clears stale context before the next open.

Closes #783
