### PR TITLE
Fix empty fields not being discoverable as field context #805

### DIFF
--- a/src/main/resources/assets/index.tsx
+++ b/src/main/resources/assets/index.tsx
@@ -5,6 +5,7 @@ import { injectHostStyles } from '@/shadow/injectHostStyles';
 import { injectStyles } from '@/shadow/injectStyles';
 import { ShadowHostContext } from '@/shadow/ShadowHostContext';
 import { registerThemeHost } from '@/shadow/themeSync';
+import { isResolvableContext } from '@/store/content';
 import { setContext, resetContext } from '@/store/context';
 import { setDialogHidden } from '@/store/dialog';
 import {
@@ -59,11 +60,15 @@ function mount(container: HTMLElement, context: AiPluginContext): AiPluginInstan
     context.api.on('dialog:open', () => setDialogHidden(false)),
     context.api.on('dialog:close', () => setDialogHidden(true)),
     context.api.on('context:set', (path) => {
-      if (path != null) {
-        setContext(path);
-      } else {
+      if (path == null) {
         resetContext();
+        return;
       }
+      // A field the operator can't act on (e.g. non-text): keep the previous context, not a dead one.
+      if (!isResolvableContext(path)) {
+        return;
+      }
+      setContext(path);
     }),
   ];
 

--- a/src/main/resources/assets/store/content/content.store.test.ts
+++ b/src/main/resources/assets/store/content/content.store.test.ts
@@ -3,8 +3,15 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import type { ContentData, PropertyValue } from './ContentData';
 import type { Path } from './Path';
+import type { Schema } from './Schema';
 
-import { findValueByPath, setLanguage, setPersistedData } from './content.store';
+import {
+  findValueByPath,
+  isResolvableContext,
+  setLanguage,
+  setPersistedData,
+  setSchema,
+} from './content.store';
 import { setValueByPath } from './content.utils';
 
 beforeAll(() => {
@@ -104,6 +111,57 @@ describe('setValueByPath', () => {
     expect(received).toEqual(expected);
   });
 });
+
+describe('isResolvableContext', () => {
+  it('resolves an editable field that has no stored value', () => {
+    setSchema(getResolvableSchema());
+    setPersistedData(getResolvableData());
+
+    expect(isResolvableContext('/baseUrl')).toBe(true);
+  });
+
+  it('does not resolve a path that matches no editable field', () => {
+    setSchema(getResolvableSchema());
+    setPersistedData(getResolvableData());
+
+    expect(isResolvableContext('/doesNotExist')).toBe(false);
+  });
+});
+
+function getResolvableSchema(): Schema {
+  return {
+    form: {
+      formItems: [
+        {
+          Input: {
+            name: 'description',
+            label: 'Description',
+            occurrences: { maximum: 1, minimum: 0 },
+            inputType: 'TextLine',
+          },
+        },
+        {
+          Input: {
+            name: 'baseUrl',
+            label: 'Base URL',
+            occurrences: { maximum: 1, minimum: 0 },
+            inputType: 'TextLine',
+          },
+        },
+      ],
+    },
+    name: 'Test',
+  };
+}
+
+function getResolvableData(): ContentData {
+  return {
+    contentId: '1',
+    contentPath: '/x',
+    fields: [{ name: 'description', type: 'String', values: [{ v: 'hello' }] }],
+    topic: 'topic',
+  };
+}
 
 function getRootTextItems(): ContentData {
   return {

--- a/src/main/resources/assets/store/content/content.store.ts
+++ b/src/main/resources/assets/store/content/content.store.ts
@@ -83,28 +83,35 @@ const $helpTextMap = computed($allFormItemsWithPaths, (items) => {
   );
 });
 
-export const $inputsInContext = computed(
-  [$context, $allFormItemsWithPaths],
-  (context, allFormItems) => {
-    const contextPath = context && pathFromString(context);
+function resolveInputsForContext(
+  contextPath: Optional<Path>,
+  allFormItems: FormItemWithPath[],
+): InputWithPath[] {
+  const input = contextPath
+    ? allFormItems.find(
+        (path): path is InputWithPath => pathsEqual(path, contextPath) && isEditableInput(path),
+      )
+    : null;
 
-    const input = contextPath
-      ? allFormItems.find(
-          (path): path is InputWithPath => pathsEqual(path, contextPath) && isEditableInput(path),
-        )
-      : null;
+  if (input) {
+    return [input];
+  }
 
-    if (input) {
-      return [input];
-    }
+  const items: FormItemWithPath[] = contextPath
+    ? allFormItems.filter((path) => isChildPath(path, contextPath))
+    : allFormItems.filter((path) => isRootPath(path));
 
-    const items: FormItemWithPath[] = contextPath
-      ? allFormItems.filter((path) => isChildPath(path, contextPath))
-      : allFormItems.filter((path) => isRootPath(path));
+  return items.filter((item: FormItemWithPath): item is InputWithPath => isEditableInput(item));
+}
 
-    return items.filter((item: FormItemWithPath): item is InputWithPath => isEditableInput(item));
-  },
+export const $inputsInContext = computed([$context, $allFormItemsWithPaths], (context, allFormItems) =>
+  resolveInputsForContext(context ? pathFromString(context) : null, allFormItems),
 );
+
+// True when the path resolves to an editable input: the field itself, or a parent's editable children.
+export function isResolvableContext(context: string): boolean {
+  return resolveInputsForContext(pathFromString(context), $allFormItemsWithPaths.get()).length > 0;
+}
 
 export const $mentions = computed([$inputsInContext], (inputs) => {
   const mentions = inputs.map(pathToMention);

--- a/src/main/resources/assets/store/content/content.utils.test.ts
+++ b/src/main/resources/assets/store/content/content.utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import type { ContentData } from './ContentData';
 import type { Schema } from './Schema';
 
-import { getFormItemsWithPaths } from './content.utils';
+import { getDataPathsToEditableItems, getFormItemsWithPaths, pathToString } from './content.utils';
 
 describe('schemaUtil', () => {
   it('should return two top items', () => {
@@ -751,6 +752,177 @@ describe('schemaUtil', () => {
     ];
 
     expect(received).toEqual(expected);
+  });
+});
+
+describe('getDataPathsToEditableItems', () => {
+  it('includes an editable input with no stored value at an index-less path', () => {
+    const schema: Schema = {
+      form: {
+        formItems: [
+          {
+            Input: {
+              name: 'description',
+              label: 'Description',
+              occurrences: { maximum: 1, minimum: 0 },
+              inputType: 'TextLine',
+            },
+          },
+          {
+            Input: {
+              name: 'baseUrl',
+              label: 'Base URL',
+              occurrences: { maximum: 1, minimum: 0 },
+              inputType: 'TextLine',
+            },
+          },
+        ],
+      },
+      name: 'Test',
+    };
+
+    const data: ContentData = {
+      contentId: '1',
+      contentPath: '/x',
+      fields: [{ name: 'description', type: 'String', values: [{ v: 'hello' }] }],
+      topic: 'topic',
+    };
+
+    const received = getDataPathsToEditableItems(
+      getFormItemsWithPaths(schema.form.formItems),
+      data,
+    ).map(pathToString);
+
+    expect(received).toContain('/description');
+    expect(received).toContain('/baseUrl');
+  });
+
+  it('does not include inputs inside an uninstantiated set', () => {
+    const schema: Schema = {
+      form: {
+        formItems: [
+          {
+            FormItemSet: {
+              name: 'mySet',
+              label: 'My Set',
+              occurrences: { maximum: 5, minimum: 0 },
+              items: [
+                {
+                  Input: {
+                    name: 'inner',
+                    label: 'Inner',
+                    occurrences: { maximum: 1, minimum: 0 },
+                    inputType: 'TextLine',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      name: 'Test',
+    };
+
+    const data: ContentData = { contentId: '1', contentPath: '/x', fields: [], topic: 'topic' };
+
+    const received = getDataPathsToEditableItems(
+      getFormItemsWithPaths(schema.form.formItems),
+      data,
+    ).map(pathToString);
+
+    expect(received).not.toContain('/mySet/inner');
+  });
+
+  it('includes an empty input inside an instantiated set', () => {
+    const schema: Schema = {
+      form: {
+        formItems: [
+          {
+            FormItemSet: {
+              name: 'mySet',
+              label: 'My Set',
+              occurrences: { maximum: 5, minimum: 0 },
+              items: [
+                {
+                  Input: {
+                    name: 'inner',
+                    label: 'Inner',
+                    occurrences: { maximum: 1, minimum: 0 },
+                    inputType: 'TextLine',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      name: 'Test',
+    };
+
+    const data: ContentData = {
+      contentId: '1',
+      contentPath: '/x',
+      fields: [{ name: 'mySet', type: 'PropertySet', values: [{ set: [] }] }],
+      topic: 'topic',
+    };
+
+    const received = getDataPathsToEditableItems(
+      getFormItemsWithPaths(schema.form.formItems),
+      data,
+    ).map(pathToString);
+
+    expect(received).toContain('/mySet/inner');
+  });
+
+  it('emits a per-occurrence leaf path when one occurrence of a repeated set is empty', () => {
+    const schema: Schema = {
+      form: {
+        formItems: [
+          {
+            FormItemSet: {
+              name: 'mySet',
+              label: 'My Set',
+              occurrences: { maximum: 5, minimum: 0 },
+              items: [
+                {
+                  Input: {
+                    name: 'inner',
+                    label: 'Inner',
+                    occurrences: { maximum: 1, minimum: 0 },
+                    inputType: 'TextLine',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      name: 'Test',
+    };
+
+    const data: ContentData = {
+      contentId: '1',
+      contentPath: '/x',
+      fields: [
+        {
+          name: 'mySet',
+          type: 'PropertySet',
+          values: [
+            { set: [{ name: 'inner', type: 'String', values: [{ v: 'filled' }] }] },
+            { set: [] },
+          ],
+        },
+      ],
+      topic: 'topic',
+    };
+
+    const received = getDataPathsToEditableItems(
+      getFormItemsWithPaths(schema.form.formItems),
+      data,
+    ).map(pathToString);
+
+    expect(received).toContain('/mySet/inner');
+    expect(received).toContain('/mySet[1]/inner');
   });
 });
 

--- a/src/main/resources/assets/store/content/content.utils.ts
+++ b/src/main/resources/assets/store/content/content.utils.ts
@@ -356,6 +356,7 @@ function createPropertyPaths(
   properties: PropertyArray[] | undefined,
   schemaPath: Path,
   previousIterationResult: Path[],
+  emitEmptyLeaf: boolean,
 ): Path[] {
   const pathElement = schemaPath.elements.shift();
 
@@ -366,6 +367,17 @@ function createPropertyPaths(
   const propertyArray = properties.find((propertyArray) => propertyArray.name === pathElement.name);
 
   if (!propertyArray || propertyArray.values.length === 0) {
+    // An empty leaf input still renders as a field, so emit it at an index-less
+    // path; a missing non-leaf is an uninstantiated set with nothing to focus.
+    if (emitEmptyLeaf && schemaPath.elements.length === 0) {
+      const leafPath =
+        previousIterationResult.length > 0
+          ? clonePath(previousIterationResult[0])
+          : { elements: [] };
+      leafPath.elements.push({ name: pathElement.name, label: pathElement.label });
+      return [leafPath];
+    }
+
     return previousIterationResult;
   }
 
@@ -382,7 +394,9 @@ function createPropertyPaths(
       previousIterationResult.length > 0 ? clonePath(previousIterationResult[0]) : { elements: [] };
     newPath.elements.push(newPathElement);
 
-    thisIterationResult.push(...createPropertyPaths(value.set, clonePath(schemaPath), [newPath]));
+    thisIterationResult.push(
+      ...createPropertyPaths(value.set, clonePath(schemaPath), [newPath], emitEmptyLeaf),
+    );
   });
 
   return thisIterationResult;
@@ -393,9 +407,12 @@ export function getDataPathsToEditableItems(
   data: ContentData,
 ): FormItemWithPath[] {
   return schemaPaths.flatMap((schemaPath: FormItemWithPath) => {
-    const dataPaths = createPropertyPaths(data.fields, clonePath(schemaPath), []).filter(
-      (dataPath) => dataPath.elements.length === schemaPath.elements.length,
-    );
+    const dataPaths = createPropertyPaths(
+      data.fields,
+      clonePath(schemaPath),
+      [],
+      isInput(schemaPath),
+    ).filter((dataPath) => dataPath.elements.length === schemaPath.elements.length);
 
     return dataPaths.map((dataPath) => {
       if (isInput(schemaPath)) {


### PR DESCRIPTION
## Changes

- Expose editable inputs with no stored value at an index-less path, so focusing an empty field resolves as context (`createPropertyPaths` / `getDataPathsToEditableItems`)
- Ignore an unresolvable `context:set` path and keep the previous context instead of rendering dead context controls; add `isResolvableContext`
- Add tests for empty-leaf emission (including repeated sets) and context resolvability

Closes #805

<sub>*Drafted with AI assistance*</sub>
