### PR TITLE
Support Application Default Credentials for Google authentication #828

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,42 +25,71 @@ This applications relies on access to the Google Cloud Vertex API which provides
 
 ## Configuration
 
-### Create Google Cloud Service Account
+The application authenticates to Google in one of two ways. When `google.api.sak.path` is set, the credentials at that path are used. When it is absent, the application falls back to [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (ADC).
 
-You will need a valid Google Service Account Key (SAK) in JSON format and store it in your XP configuration.
+Whichever you choose, the service account or user needs the role `Vertex AI User (roles/aiplatform.user)`, or a custom role granting `aiplatform.endpoints.predict`. Activate the API in the Google Cloud console first.
 
-1. **Activate Vertex API**
+### Option 1: Application Default Credentials
 
-   In Google Cloud console. Search for and activate the Google Vertex API
+Suitable for local development, CI using Workload Identity Federation, and instances running on Google Cloud with an attached service account. No key file is created or distributed.
 
-2. **Create Service Account**
+For local development, leave `google.api.sak.path` unset and run:
 
-   From the Google cloud IAM. Create a service account and make sure it has the role `Vertex AI User (roles/aiplatform.user)`
+```shell
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT=<your project id>
+```
 
-3. **Create a Service Account Key (SAK)**
+ADC resolves credentials from `GOOGLE_APPLICATION_CREDENTIALS`, then the well-known `gcloud` location, then the Google Cloud metadata server. XP inherits these from the environment it is started in, so no application configuration is required.
+
+> [!NOTE]
+> If XP runs in a container, credentials written by `gcloud` on the host are not visible inside it. Mount them read-only with `-v ~/.config/gcloud:/root/.config/gcloud:ro`, or point `GOOGLE_APPLICATION_CREDENTIALS` at a mounted path.
+
+### Option 2: Service Account Key
+
+Required when XP runs somewhere that cannot obtain credentials from its environment.
+
+1. **Create Service Account**
+
+   From the Google cloud IAM. Create a service account and grant it the role described above.
+
+2. **Create a Service Account Key (SAK)**
 
    Using your Service Account, create a new Service Account Key. The key will download automatically to your local machine.
 
-### Configure the application
-
-1. **Upload SAK**
+3. **Upload SAK**
 
    Place it in your `$XP_HOME/config` directory, or a subdirectory
 
-2. **Create an app configuration file**
+4. **Create an app configuration file**
 
    Place the file `com.enonic.app.ai.contentoperator.cfg` in your `$XP_HOME/config` directory.
    Add a configuration value `google.api.sak.path : <Path to the Google Service Account Key (SAK) file>` within the config file
 
    > Use Unix-style paths or properly escape backslashes for windows system
 
+### Google Cloud project
+
+The project is resolved in this order:
+
+1. The `google.api.project.id` configuration value
+2. The `project_id` field of a Service Account Key, when one is configured
+3. The `GOOGLE_CLOUD_PROJECT` environment variable
+
+A Service Account Key therefore needs no further configuration, while ADC user credentials — which carry no project — require one of the other two. The project is not needed at all when both `google.api.gemini.flash.url` and `google.api.gemini.pro.url` are overridden.
+
 ## Example config file
 
 `com.enonic.app.ai.contentoperator.cfg (sample)`
 
 ```properties
-# Path to Google's Service Account Key (a JSON file)
+# (Optional) Path to Google's Service Account Key (a JSON file).
+# Leave unset to use Application Default Credentials.
 google.api.sak.path=${xp.home}/config/playground-123456-e13cb1841f87.json
+
+# (Optional) Google Cloud project ID.
+# Required with Application Default Credentials, unless GOOGLE_CLOUD_PROJECT is set.
+google.api.project.id=playground-123456
 
 # (Optional) (Default: "all") A comma separated list of debug groups to limit the debug output, not enforce it.
 # Possible values: all, none, google, func, ws

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gcloud auth application-default login
 export GOOGLE_CLOUD_PROJECT=<your project id>
 ```
 
-ADC resolves credentials from `GOOGLE_APPLICATION_CREDENTIALS`, then the well-known `gcloud` location, then the Google Cloud metadata server. XP inherits these from the environment it is started in, so no application configuration is required.
+ADC resolves credentials from `GOOGLE_APPLICATION_CREDENTIALS`, then the well-known `gcloud` location, then the Google Cloud metadata server. XP inherits these from the environment it is started in, so no credentials configuration is required. The project is resolved separately — see [Google Cloud project](#google-cloud-project).
 
 > [!NOTE]
 > If XP runs in a container, credentials written by `gcloud` on the host are not visible inside it. Mount them read-only with `-v ~/.config/gcloud:/root/.config/gcloud:ro`, or point `GOOGLE_APPLICATION_CREDENTIALS` at a mounted path.
@@ -73,10 +73,10 @@ Required when XP runs somewhere that cannot obtain credentials from its environm
 The project is resolved in this order:
 
 1. The `google.api.project.id` configuration value
-2. The `project_id` field of a Service Account Key, when one is configured
+2. The project carried by the credentials — the `project_id` field of a Service Account Key, or, on a Google Cloud instance, the project of the attached service account as reported by the metadata server
 3. The `GOOGLE_CLOUD_PROJECT` environment variable
 
-A Service Account Key therefore needs no further configuration, while ADC user credentials — which carry no project — require one of the other two. The project is not needed at all when both `google.api.gemini.flash.url` and `google.api.gemini.pro.url` are overridden.
+A Service Account Key and a Google Cloud instance therefore need no further configuration, while ADC user credentials — which carry no project — require one of the other two. The project is not needed at all when both `google.api.gemini.flash.url` and `google.api.gemini.pro.url` are overridden.
 
 ## Example config file
 
@@ -88,7 +88,8 @@ A Service Account Key therefore needs no further configuration, while ADC user c
 google.api.sak.path=${xp.home}/config/playground-123456-e13cb1841f87.json
 
 # (Optional) Google Cloud project ID.
-# Required with Application Default Credentials, unless GOOGLE_CLOUD_PROJECT is set.
+# Required with Application Default Credentials, unless the credentials carry a project
+# (a Google Cloud instance does) or GOOGLE_CLOUD_PROJECT is set.
 google.api.project.id=playground-123456
 
 # (Optional) (Default: "all") A comma separated list of debug groups to limit the debug output, not enforce it.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A pre-buit version of the application can be installed from [Enonic Market](http
 
 ## Requirements
 
-This applications relies on access to the Google Cloud Vertex API which provides a range of different AI models.
+This application relies on access to the Google Cloud Gemini Enterprise Agent Platform, formerly known as Vertex AI, which provides a range of different AI models.
 
 > [!NOTE]
 > Enonic will provision access to AI services for subscription customers without any additional charge, please get in touch. [Create a support ticket](https://support.enonic.com)
@@ -27,7 +27,7 @@ This applications relies on access to the Google Cloud Vertex API which provides
 
 The application authenticates to Google in one of two ways. When `google.api.sak.path` is set, the credentials at that path are used. When it is absent, the application falls back to [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (ADC).
 
-Whichever you choose, the service account or user needs the role `Vertex AI User (roles/aiplatform.user)`, or a custom role granting `aiplatform.endpoints.predict`. Activate the API in the Google Cloud console first.
+Whichever you choose, enable the Agent Platform API (`aiplatform.googleapis.com`) in the Google Cloud console first, then grant the service account or user the role `Gemini Enterprise Agent Platform User (roles/aiplatform.user)`, or a custom role granting `aiplatform.endpoints.predict`.
 
 ### Option 1: Application Default Credentials
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ ADC resolves credentials from `GOOGLE_APPLICATION_CREDENTIALS`, then the well-kn
 > [!NOTE]
 > If XP runs in a container, credentials written by `gcloud` on the host are not visible inside it. Mount them read-only with `-v ~/.config/gcloud:/root/.config/gcloud:ro`, or point `GOOGLE_APPLICATION_CREDENTIALS` at a mounted path.
 
-### Option 2: Service Account Key
+### Option 2: Service Account Key or other credentials file
 
-Required when XP runs somewhere that cannot obtain credentials from its environment.
+Required when XP runs somewhere that cannot obtain credentials from its environment. A Service Account Key is the usual choice; see the note below for the other accepted formats.
 
 1. **Create Service Account**
 
@@ -64,9 +64,12 @@ Required when XP runs somewhere that cannot obtain credentials from its environm
 4. **Create an app configuration file**
 
    Place the file `com.enonic.app.ai.contentoperator.cfg` in your `$XP_HOME/config` directory.
-   Add a configuration value `google.api.sak.path : <Path to the Google Service Account Key (SAK) file>` within the config file
+   Add a configuration value `google.api.sak.path : <Path to the credentials file>` within the config file
 
    > Use Unix-style paths or properly escape backslashes for windows system
+
+> [!NOTE]
+> Despite its name, `google.api.sak.path` also accepts the other credentials formats Google's client libraries read: an external account (Workload Identity Federation) configuration, a service account impersonation configuration, and an authorized user file. This is useful when XP cannot see `GOOGLE_APPLICATION_CREDENTIALS` but can read a mounted file. Of these, only a Service Account Key carries a `project_id`, so the others need the project configured — see [Google Cloud project](#google-cloud-project).
 
 ### Google Cloud project
 
@@ -76,14 +79,14 @@ The project is resolved in this order:
 2. The project carried by the credentials — the `project_id` field of a Service Account Key, or, on a Google Cloud instance, the project of the attached service account as reported by the metadata server
 3. The `GOOGLE_CLOUD_PROJECT` environment variable
 
-A Service Account Key and a Google Cloud instance therefore need no further configuration, while ADC user credentials — which carry no project — require one of the other two. The project is not needed at all when both `google.api.gemini.flash.url` and `google.api.gemini.pro.url` are overridden.
+A Service Account Key and a Google Cloud instance therefore need no further configuration. Every other credential — a `gcloud` user login, and the external account, impersonation, and authorized user formats — carries no project and requires one of the other two. The project is not needed at all when both `google.api.gemini.flash.url` and `google.api.gemini.pro.url` are overridden.
 
 ## Example config file
 
 `com.enonic.app.ai.contentoperator.cfg (sample)`
 
 ```properties
-# (Optional) Path to Google's Service Account Key (a JSON file).
+# (Optional) Path to Google's Service Account Key, or any other credentials JSON file.
 # Leave unset to use Application Default Credentials.
 google.api.sak.path=${xp.home}/config/playground-123456-e13cb1841f87.json
 

--- a/src/main/java/com/enonic/app/ai/contentoperator/google/ServiceAccountKeyHandler.java
+++ b/src/main/java/com/enonic/app/ai/contentoperator/google/ServiceAccountKeyHandler.java
@@ -10,13 +10,16 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 
 public class ServiceAccountKeyHandler {
 
     private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
-    private ServiceAccountCredentials credentials;
+    private static final String PROJECT_ID_ENV = "GOOGLE_CLOUD_PROJECT";
+
+    private GoogleCredentials credentials;
 
     private byte[] checksum;
 
@@ -26,33 +29,63 @@ public class ServiceAccountKeyHandler {
         try {
             return credentials.refreshAccessToken().getTokenValue();
         } catch (IOException e) {
-            throw new IOException("Failed to refresh Access Token using Service AccountKey.", e);
+            throw new IOException("Failed to refresh Access Token.", e);
         }
     }
 
     public synchronized String getProjectId(String serviceAccountKeyPath)
             throws IOException {
         updateCredentialsIfNeeded(serviceAccountKeyPath);
-        return credentials.getProjectId();
+
+        if (credentials instanceof ServiceAccountCredentials) {
+            final String projectId = ((ServiceAccountCredentials) credentials).getProjectId();
+            if (projectId != null && !projectId.isBlank()) {
+                return projectId;
+            }
+        }
+
+        return System.getenv(PROJECT_ID_ENV);
     }
 
     private void updateCredentialsIfNeeded(String serviceAccountKeyPath)
             throws IOException {
+        if (serviceAccountKeyPath == null || serviceAccountKeyPath.isBlank()) {
+            // ? checksum is null only while credentials come from ADC, so a switch away from a key file reloads
+            if (credentials == null || checksum != null) {
+                this.credentials = applyScope(loadApplicationDefaultCredentials());
+                this.checksum = null;
+            }
+            return;
+        }
+
         final byte[] currentChecksum = calculateChecksum(Paths.get(serviceAccountKeyPath));
 
         if (credentials == null || !MessageDigest.isEqual(checksum, currentChecksum)) {
-            this.credentials
-                    = (ServiceAccountCredentials) loadCredentialsFromFile(serviceAccountKeyPath).createScoped(CLOUD_PLATFORM_SCOPE);
+            this.credentials = applyScope(loadCredentialsFromFile(serviceAccountKeyPath));
             this.checksum = currentChecksum;
         }
     }
 
-    private ServiceAccountCredentials loadCredentialsFromFile(String serviceAccountKeyPath)
+    // ! User credentials carry their scopes in the refresh token and reject scoping
+    private GoogleCredentials applyScope(GoogleCredentials credentials) {
+        return credentials.createScopedRequired() ? credentials.createScoped(CLOUD_PLATFORM_SCOPE) : credentials;
+    }
+
+    private GoogleCredentials loadApplicationDefaultCredentials()
+            throws IOException {
+        try {
+            return GoogleCredentials.getApplicationDefault();
+        } catch (IOException e) {
+            throw new IOException("Failed to load Application Default Credentials.", e);
+        }
+    }
+
+    private GoogleCredentials loadCredentialsFromFile(String serviceAccountKeyPath)
             throws IOException {
         try (FileInputStream fileInputStream = new FileInputStream(serviceAccountKeyPath)) {
-            return ServiceAccountCredentials.fromStream(fileInputStream);
+            return GoogleCredentials.fromStream(fileInputStream);
         } catch (IOException e) {
-            throw new IOException("Failed to load Service Account Key from file: " + serviceAccountKeyPath, e);
+            throw new IOException("Failed to load credentials from file: " + serviceAccountKeyPath, e);
         }
     }
 

--- a/src/main/java/com/enonic/app/ai/contentoperator/google/ServiceAccountKeyHandler.java
+++ b/src/main/java/com/enonic/app/ai/contentoperator/google/ServiceAccountKeyHandler.java
@@ -11,7 +11,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
 
 public class ServiceAccountKeyHandler {
 
@@ -37,14 +36,22 @@ public class ServiceAccountKeyHandler {
             throws IOException {
         updateCredentialsIfNeeded(serviceAccountKeyPath);
 
-        if (credentials instanceof ServiceAccountCredentials) {
-            final String projectId = ((ServiceAccountCredentials) credentials).getProjectId();
-            if (projectId != null && !projectId.isBlank()) {
-                return projectId;
-            }
+        final String projectId = readProjectIdFromCredentials();
+        if (projectId != null && !projectId.isBlank()) {
+            return projectId;
         }
 
         return System.getenv(PROJECT_ID_ENV);
+    }
+
+    // ? Only Service Account Key and Compute Engine credentials carry a project; the rest return null
+    private String readProjectIdFromCredentials() {
+        try {
+            return credentials.getProjectId();
+        } catch (RuntimeException e) {
+            // ! ComputeEngineCredentials throws NPE on a cause-less IOException; the env fallback must still run
+            return null;
+        }
     }
 
     private void updateCredentialsIfNeeded(String serviceAccountKeyPath)

--- a/src/main/resources/assets/store/chat/chat.utils.ts
+++ b/src/main/resources/assets/store/chat/chat.utils.ts
@@ -376,8 +376,8 @@ function getErrorMessageText(payload: FailedMessagePayload | string): string {
 
 function getErrorMessageByCode(code: number): string {
   switch (code) {
-    case ERRORS.GOOGLE_SAK_MISSING.code:
-    case ERRORS.GOOGLE_SAK_READ_FAILED.code:
+    case ERRORS.GOOGLE_ADC_FAILED.code:
+    case ERRORS.GOOGLE_CREDENTIALS_FILE_FAILED.code:
     case ERRORS.GOOGLE_ACCESS_TOKEN_MISSING.code:
     case ERRORS.GOOGLE_PROJECT_ID_MISSING.code:
       return t('text.error.configuration');

--- a/src/main/resources/lib/config.test.ts
+++ b/src/main/resources/lib/config.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = globalThis as unknown as { app: { config: Record<string, string | undefined> } };
+const originalConfig = runtime.app.config;
+
+async function loadConfig(config: Record<string, string | undefined>) {
+  vi.resetModules();
+  runtime.app.config = config;
+
+  return import('./config');
+}
+
+describe('config', () => {
+  afterEach(() => {
+    runtime.app.config = originalConfig;
+  });
+
+  it('should read a configured value', async () => {
+    const { GOOGLE_PROJECT_ID } = await loadConfig({ 'google.api.project.id': 'playground-123456' });
+
+    expect(GOOGLE_PROJECT_ID).toBe('playground-123456');
+  });
+
+  it('should read an unset value as null', async () => {
+    const { GOOGLE_PROJECT_ID } = await loadConfig({});
+
+    expect(GOOGLE_PROJECT_ID).toBeNull();
+  });
+
+  it('should read an empty value as null', async () => {
+    const { GOOGLE_PROJECT_ID } = await loadConfig({ 'google.api.project.id': '' });
+
+    expect(GOOGLE_PROJECT_ID).toBeNull();
+  });
+
+  it('should read a whitespace-only value as null', async () => {
+    const { GOOGLE_PROJECT_ID } = await loadConfig({ 'google.api.project.id': '   ' });
+
+    expect(GOOGLE_PROJECT_ID).toBeNull();
+  });
+
+  it('should trim surrounding whitespace', async () => {
+    const { GOOGLE_SAK_PATH } = await loadConfig({
+      'google.api.sak.path': '  /xp/config/key.json  ',
+    });
+
+    expect(GOOGLE_SAK_PATH).toBe('/xp/config/key.json');
+  });
+
+  it('should normalize every text value', async () => {
+    const config = await loadConfig({
+      'google.api.gemini.flash.url': '  ',
+      'google.api.gemini.pro.url': '',
+      'google.api.project.id': ' ',
+      'google.api.sak.path': '\t',
+    });
+
+    expect(config.GOOGLE_GEMINI_FLASH_URL).toBeNull();
+    expect(config.GOOGLE_GEMINI_PRO_URL).toBeNull();
+    expect(config.GOOGLE_PROJECT_ID).toBeNull();
+    expect(config.GOOGLE_SAK_PATH).toBeNull();
+  });
+});

--- a/src/main/resources/lib/config.ts
+++ b/src/main/resources/lib/config.ts
@@ -1,9 +1,18 @@
-export const GOOGLE_GEMINI_FLASH_URL: string | null =
-  app.config['google.api.gemini.flash.url'] ?? null;
-export const GOOGLE_GEMINI_PRO_URL: string | null = app.config['google.api.gemini.pro.url'] ?? null;
-export const GOOGLE_PROJECT_ID: string | null = app.config['google.api.project.id'] ?? null;
-export const GOOGLE_SAK_PATH: string | null = app.config['google.api.sak.path'] ?? null;
+export const GOOGLE_GEMINI_FLASH_URL: string | null = parseText(
+  app.config['google.api.gemini.flash.url'],
+);
+export const GOOGLE_GEMINI_PRO_URL: string | null = parseText(
+  app.config['google.api.gemini.pro.url'],
+);
+export const GOOGLE_PROJECT_ID: string | null = parseText(app.config['google.api.project.id']);
+export const GOOGLE_SAK_PATH: string | null = parseText(app.config['google.api.sak.path']);
 export const DEBUG_GROUPS: string[] = parseList(app.config['log.debug.groups']);
+
+// ? A blank value must read as absent, so the fallbacks behind it still run
+function parseText(value: string | undefined): string | null {
+  const text = value?.trim();
+  return text != null && text.length > 0 ? text : null;
+}
 
 function parseList(value: string | undefined, defaultValue = ''): string[] {
   return (value ?? defaultValue)

--- a/src/main/resources/lib/config.ts
+++ b/src/main/resources/lib/config.ts
@@ -1,6 +1,7 @@
 export const GOOGLE_GEMINI_FLASH_URL: string | null =
   app.config['google.api.gemini.flash.url'] ?? null;
 export const GOOGLE_GEMINI_PRO_URL: string | null = app.config['google.api.gemini.pro.url'] ?? null;
+export const GOOGLE_PROJECT_ID: string | null = app.config['google.api.project.id'] ?? null;
 export const GOOGLE_SAK_PATH: string | null = app.config['google.api.sak.path'] ?? null;
 export const DEBUG_GROUPS: string[] = parseList(app.config['log.debug.groups']);
 

--- a/src/main/resources/lib/google/options.test.ts
+++ b/src/main/resources/lib/google/options.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ERRORS } from '../../shared/errors';
+
+type ConfigOverrides = {
+  GOOGLE_GEMINI_FLASH_URL?: string | null;
+  GOOGLE_GEMINI_PRO_URL?: string | null;
+  GOOGLE_PROJECT_ID?: string | null;
+  GOOGLE_SAK_PATH?: string | null;
+};
+
+type Handler = {
+  getAccessToken: ReturnType<typeof vi.fn>;
+  getProjectId: ReturnType<typeof vi.fn>;
+};
+
+type HandlerOverrides = {
+  accessToken?: string;
+  projectId?: string | null;
+};
+
+function buildHandler({
+  accessToken = 'token-123',
+  projectId = null,
+}: HandlerOverrides = {}): Handler {
+  return {
+    getAccessToken: vi.fn(() => accessToken),
+    getProjectId: vi.fn(() => projectId),
+  };
+}
+
+const bridge = globalThis as unknown as { __: { newBean: unknown } };
+const originalNewBean = bridge.__.newBean;
+
+async function loadOptions(config: ConfigOverrides, handler: Handler) {
+  vi.resetModules();
+  vi.doMock('../config', () => ({
+    GOOGLE_GEMINI_FLASH_URL: null,
+    GOOGLE_GEMINI_PRO_URL: null,
+    GOOGLE_PROJECT_ID: null,
+    GOOGLE_SAK_PATH: null,
+    DEBUG_GROUPS: [],
+    ...config,
+  }));
+
+  bridge.__.newBean = () => handler;
+
+  return import('./options');
+}
+
+describe('parseOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    bridge.__.newBean = originalNewBean;
+    vi.doUnmock('../config');
+  });
+
+  it('should prefer the configured project id over the credentials project', async () => {
+    const handler = buildHandler({ projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({ GOOGLE_PROJECT_ID: 'from-config' }, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(err).toBeNull();
+    expect(options?.flash.url).toContain('/projects/from-config/');
+    expect(handler.getProjectId).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to the credentials project id', async () => {
+    const handler = buildHandler({ projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({}, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(err).toBeNull();
+    expect(options?.pro.url).toContain('/projects/from-key/');
+  });
+
+  it('should resolve the project id once for both models', async () => {
+    const handler = buildHandler({ projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({}, handler);
+
+    parseOptions();
+
+    expect(handler.getProjectId).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail when no project id is available', async () => {
+    const handler = buildHandler({ projectId: null });
+    const { parseOptions } = await loadOptions({}, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(options).toBeNull();
+    expect(err?.code).toBe(ERRORS.GOOGLE_PROJECT_ID_MISSING.code);
+  });
+
+  it('should not require a project id when both model urls are overridden', async () => {
+    const handler = buildHandler({ projectId: null });
+    const { parseOptions } = await loadOptions(
+      {
+        GOOGLE_GEMINI_FLASH_URL: 'https://example.test/flash',
+        GOOGLE_GEMINI_PRO_URL: 'https://example.test/pro',
+      },
+      handler,
+    );
+
+    const [options, err] = parseOptions();
+
+    expect(err).toBeNull();
+    expect(options?.flash.url).toBe('https://example.test/flash:generateContent');
+    expect(options?.pro.url).toBe('https://example.test/pro:generateContent');
+    expect(handler.getProjectId).not.toHaveBeenCalled();
+  });
+
+  it('should pass the configured key path to the handler', async () => {
+    const handler = buildHandler({ projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({ GOOGLE_SAK_PATH: '/xp/config/key.json' }, handler);
+
+    parseOptions();
+
+    expect(handler.getAccessToken).toHaveBeenCalledWith('/xp/config/key.json');
+  });
+
+  it('should pass a null key path to the handler when unset', async () => {
+    const handler = buildHandler({ projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({}, handler);
+
+    parseOptions();
+
+    expect(handler.getAccessToken).toHaveBeenCalledWith(null);
+  });
+
+  it('should fail when the access token is missing', async () => {
+    const handler = buildHandler({ accessToken: '', projectId: 'from-key' });
+    const { parseOptions } = await loadOptions({}, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(options).toBeNull();
+    expect(err?.code).toBe(ERRORS.GOOGLE_ACCESS_TOKEN_MISSING.code);
+  });
+});

--- a/src/main/resources/lib/google/options.test.ts
+++ b/src/main/resources/lib/google/options.test.ts
@@ -29,6 +29,15 @@ function buildHandler({
   };
 }
 
+function buildFailingHandler(): Handler {
+  return {
+    getAccessToken: vi.fn(() => {
+      throw new Error('java.io.IOException: boom');
+    }),
+    getProjectId: vi.fn(),
+  };
+}
+
 const bridge = globalThis as unknown as { __: { newBean: unknown } };
 const originalNewBean = bridge.__.newBean;
 
@@ -142,5 +151,27 @@ describe('parseOptions', () => {
 
     expect(options).toBeNull();
     expect(err?.code).toBe(ERRORS.GOOGLE_ACCESS_TOKEN_MISSING.code);
+  });
+
+  it('should blame the credentials file when a key path is configured', async () => {
+    const handler = buildFailingHandler();
+    const { parseOptions } = await loadOptions({ GOOGLE_SAK_PATH: '/xp/config/key.json' }, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(options).toBeNull();
+    expect(err?.code).toBe(ERRORS.GOOGLE_CREDENTIALS_FILE_FAILED.code);
+    expect(err?.message).toContain('java.io.IOException: boom');
+  });
+
+  it('should blame Application Default Credentials when no key path is configured', async () => {
+    const handler = buildFailingHandler();
+    const { parseOptions } = await loadOptions({}, handler);
+
+    const [options, err] = parseOptions();
+
+    expect(options).toBeNull();
+    expect(err?.code).toBe(ERRORS.GOOGLE_ADC_FAILED.code);
+    expect(err?.message).toContain('java.io.IOException: boom');
   });
 });

--- a/src/main/resources/lib/google/options.ts
+++ b/src/main/resources/lib/google/options.ts
@@ -80,7 +80,10 @@ export function parseOptions(): Try<ClientOptions> {
 
     return [{ accessToken, flash, pro }, null];
   } catch (error) {
-    return [null, ERRORS.GOOGLE_SAK_READ_FAILED.withMsg(String(error))];
+    // ? Names the credential source rather than the failed step, since any step in the try can throw
+    const failure =
+      GOOGLE_SAK_PATH != null ? ERRORS.GOOGLE_CREDENTIALS_FILE_FAILED : ERRORS.GOOGLE_ADC_FAILED;
+    return [null, failure.withMsg(String(error))];
   }
 }
 

--- a/src/main/resources/lib/google/options.ts
+++ b/src/main/resources/lib/google/options.ts
@@ -2,7 +2,12 @@ import type { Model } from '../../shared/models';
 import type { ThinkingLevel } from './types';
 
 import { ERRORS } from '../../shared/errors';
-import { GOOGLE_GEMINI_FLASH_URL, GOOGLE_GEMINI_PRO_URL, GOOGLE_SAK_PATH } from '../config';
+import {
+  GOOGLE_GEMINI_FLASH_URL,
+  GOOGLE_GEMINI_PRO_URL,
+  GOOGLE_PROJECT_ID,
+  GOOGLE_SAK_PATH,
+} from '../config';
 import { APP_NAME } from '../constants';
 import { logDebug, LogDebugGroups, logError } from '../logger';
 
@@ -53,10 +58,6 @@ export function getModelConfig(model: Model): Try<ModelConfig> {
 export function parseOptions(): Try<ClientOptions> {
   logDebug(LogDebugGroups.GOOGLE, 'options.getOptions()');
 
-  if (!GOOGLE_SAK_PATH) {
-    return [null, ERRORS.GOOGLE_SAK_MISSING];
-  }
-
   try {
     const handler = __.newBean(`${APP_NAME}.google.ServiceAccountKeyHandler`);
 
@@ -65,30 +66,50 @@ export function parseOptions(): Try<ClientOptions> {
       return [null, ERRORS.GOOGLE_ACCESS_TOKEN_MISSING];
     }
 
-    const projectId = handler.getProjectId(GOOGLE_SAK_PATH);
-    if (!projectId) {
-      return [null, ERRORS.GOOGLE_PROJECT_ID_MISSING];
+    const resolveProjectId = createProjectIdResolver(handler);
+
+    const [flash, flashErr] = createModelConfig('flash', resolveProjectId);
+    if (flashErr) {
+      return [null, flashErr];
     }
 
-    return [
-      {
-        accessToken,
-        flash: createModelConfig('flash', projectId),
-        pro: createModelConfig('pro', projectId),
-      },
-      null,
-    ];
+    const [pro, proErr] = createModelConfig('pro', resolveProjectId);
+    if (proErr) {
+      return [null, proErr];
+    }
+
+    return [{ accessToken, flash, pro }, null];
   } catch (error) {
     return [null, ERRORS.GOOGLE_SAK_READ_FAILED.withMsg(String(error))];
   }
 }
 
-function createModelConfig(model: Model, projectId: string): ModelConfig {
-  const { modelName, thinkingLevel, urlOverride } = MODEL_DEFAULTS[model];
-  return {
-    url: createGenerateUrl(urlOverride ?? buildModelUrl(modelName, projectId)),
-    thinkingLevel,
+// ? Resolved lazily and memoized: a project id is only needed for models without a URL override
+function createProjectIdResolver(handler: ServiceAccountKeyHandler): () => Optional<string> {
+  let projectId: Optional<string>;
+
+  return () => {
+    projectId ??= GOOGLE_PROJECT_ID ?? handler.getProjectId(GOOGLE_SAK_PATH);
+    return projectId;
   };
+}
+
+function createModelConfig(
+  model: Model,
+  resolveProjectId: () => Optional<string>,
+): Try<ModelConfig> {
+  const { modelName, thinkingLevel, urlOverride } = MODEL_DEFAULTS[model];
+
+  if (urlOverride != null) {
+    return [{ url: createGenerateUrl(urlOverride), thinkingLevel }, null];
+  }
+
+  const projectId = resolveProjectId();
+  if (!projectId) {
+    return [null, ERRORS.GOOGLE_PROJECT_ID_MISSING];
+  }
+
+  return [{ url: createGenerateUrl(buildModelUrl(modelName, projectId)), thinkingLevel }, null];
 }
 
 function createGenerateUrl(baseUrl: string): string {

--- a/src/main/resources/shared/errors.ts
+++ b/src/main/resources/shared/errors.ts
@@ -60,8 +60,11 @@ export const ERRORS = {
   MODEL_GENERATION_EMPTY: err(4113, 'Generation result is empty.'),
 
   // Google Errors 5000
-  GOOGLE_SAK_MISSING: err(5000, 'Google Service Account Key is missing or invalid.'),
-  GOOGLE_SAK_READ_FAILED: err(5001, 'Failed to read Google Service Account Key.'),
+  GOOGLE_ADC_FAILED: err(5000, 'Failed to authenticate to Google using Application Default Credentials.'),
+  GOOGLE_CREDENTIALS_FILE_FAILED: err(
+    5001,
+    'Failed to authenticate to Google using the configured credentials file.',
+  ),
   GOOGLE_ACCESS_TOKEN_MISSING: err(5002, 'Google Access Token is missing or invalid.'),
   GOOGLE_PROJECT_ID_MISSING: err(5003, 'Google Project ID is missing or invalid.'),
   GOOGLE_REQUEST_FAILED: err(5010, 'Request to Google API failed.'),

--- a/src/main/resources/types/beans/ServiceAccountKeyHandler.d.ts
+++ b/src/main/resources/types/beans/ServiceAccountKeyHandler.d.ts
@@ -1,19 +1,19 @@
 declare interface ServiceAccountKeyHandler {
   /**
    * Retrieves an access token for the given service account key path.
-   * @param serviceAccountKeyPath The path to the service account key file.
+   * @param serviceAccountKeyPath The path to the service account key file, or `null` to use Application Default Credentials.
    * @returns The access token string.
    * @throws {Error} If there's an issue retrieving the access token.
    */
-  getAccessToken(serviceAccountKeyPath: string): string;
+  getAccessToken(serviceAccountKeyPath: string | null): string;
 
   /**
-   * Retrieves the project ID associated with the given service account key path.
-   * @param serviceAccountKeyPath The path to the service account key file.
-   * @returns The project ID string.
+   * Retrieves the project ID from the credentials, falling back to the `GOOGLE_CLOUD_PROJECT` environment variable.
+   * @param serviceAccountKeyPath The path to the service account key file, or `null` to use Application Default Credentials.
+   * @returns The project ID string, or `null` if the credentials carry no project and the environment variable is unset.
    * @throws {Error} If there's an issue retrieving the project ID.
    */
-  getProjectId(serviceAccountKeyPath: string): string;
+  getProjectId(serviceAccountKeyPath: string | null): string | null;
 }
 
 interface XpBeans {

--- a/src/main/resources/types/beans/ServiceAccountKeyHandler.d.ts
+++ b/src/main/resources/types/beans/ServiceAccountKeyHandler.d.ts
@@ -1,7 +1,7 @@
 declare interface ServiceAccountKeyHandler {
   /**
-   * Retrieves an access token for the given service account key path.
-   * @param serviceAccountKeyPath The path to the service account key file, or `null` to use Application Default Credentials.
+   * Retrieves an access token for the credentials at the given path.
+   * @param serviceAccountKeyPath The path to a credentials file (Service Account Key, external account, impersonation, or authorized user), or `null` to use Application Default Credentials.
    * @returns The access token string.
    * @throws {Error} If there's an issue retrieving the access token.
    */
@@ -9,7 +9,7 @@ declare interface ServiceAccountKeyHandler {
 
   /**
    * Retrieves the project ID from the credentials, falling back to the `GOOGLE_CLOUD_PROJECT` environment variable.
-   * @param serviceAccountKeyPath The path to the service account key file, or `null` to use Application Default Credentials.
+   * @param serviceAccountKeyPath The path to a credentials file (Service Account Key, external account, impersonation, or authorized user), or `null` to use Application Default Credentials.
    * @returns The project ID string, or `null` if the credentials carry no project and the environment variable is unset.
    * @throws {Error} If there's an issue retrieving the project ID.
    */


### PR DESCRIPTION
Authentication to the Gemini Enterprise Agent Platform was only possible through a Service Account Key file named in `google.api.sak.path`, so every environment required long-lived key material on disk. This adds Application Default Credentials as a fallback when that path is absent, which covers `gcloud auth application-default login` for local development, Workload Identity Federation in CI, and attached service accounts on Google Cloud through a single code path.

The existing key-file configuration is unchanged, and a configured path may now also point at a Workload Identity Federation or authorized-user file.

Three fixes were required to make this work:

- The `(ServiceAccountCredentials)` cast in `updateCredentialsIfNeeded` threw `ClassCastException` for any other credential type. It is now an `instanceof` check in `getProjectId`, which is the only place the concrete type was needed.
- `createScoped` is guarded with `createScopedRequired`, since user credentials carry their scopes in the refresh token and reject scoping.
- Project id resolution is now lazy and memoized. It was previously demanded unconditionally even though `createModelConfig` only uses it when there is no `google.api.gemini.*.url` override, which would have hard-failed a developer holding valid credentials that carry no project.

Adds `google.api.project.id`, falling back to the standard `GOOGLE_CLOUD_PROJECT` environment variable. Resolution order is the config value, then a key file's `project_id`, then the environment variable.

Also updates the README product naming, since Vertex AI became the Gemini Enterprise Agent Platform in May 2026 and the old name no longer appears in the Google Cloud console. The API is now named by host so the enable step stays findable regardless of console labelling. IAM role ids, API hostnames and configuration keys are unaffected by the rebrand and are left alone.

Closes #828