### PR TITLE
Suppress Rolldown INVALID_ANNOTATION warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,14 @@ export default defineConfig({
       formats: ['iife'],
     },
     rollupOptions: {
+      onLog(level, log, defaultHandler) {
+        // ! @enonic/ui ships a prebuilt bundle whose `/* @__PURE__ */` hints sit where
+        //   Rolldown can't attach them. The annotations are harmless, so mute the noise.
+        //   Rolldown routes these through `onLog` (not `onwarn`) and omits `id`, so drop
+        //   the whole code.
+        if (log.code === 'INVALID_ANNOTATION') return;
+        defaultHandler(level, log);
+      },
       output: {
         entryFileNames: '[name].js',
       },


### PR DESCRIPTION
The prebuilt `@enonic/ui` bundle carries `/* @__PURE__ */` annotations in positions Rolldown cannot attach, flooding every client build with `INVALID_ANNOTATION` blocks. The annotations are harmless, so the log code is dropped via an `onLog` handler on `build.rollupOptions`.

Rolldown routes these through `onLog` rather than `onwarn` and omits `log.id`, so filtering by package path is not possible — the code is dropped wholesale.

<sub>*Drafted with AI assistance*</sub>
