### PR TITLE
Upgrade pro model to Gemini 3.7 Flash #869

### DIFF
--- a/src/main/resources/lib/google/options.ts
+++ b/src/main/resources/lib/google/options.ts
@@ -34,7 +34,7 @@ const MODEL_DEFAULTS: Record<Model, ModelDefaults> = {
     urlOverride: GOOGLE_GEMINI_FLASH_URL,
   },
   pro: {
-    modelName: 'gemini-3.5-flash',
+    modelName: 'gemini-3.7-flash',
     thinkingLevel: 'low',
     urlOverride: GOOGLE_GEMINI_PRO_URL,
   },


### PR DESCRIPTION
Switched the `pro` slot from `gemini-3.5-flash` to `gemini-3.7-flash`. Same tier and same EU multi-region endpoint, stronger on coding and debugging, and half the token price at introductory rates.

The `flash` slot is unchanged on `gemini-3.1-flash-lite` — there is no 3.7 lite variant.

Verified `gemini-3.7-flash` answers on `locations/eu` via `v1`. Note this was checked against a scratch project on `aiplatform.googleapis.com`, not through the `aiplatform.eu.rep.googleapis.com` host this app uses, so it is worth a smoke test on dev before release.

Closes #869